### PR TITLE
Add Claude PR Assistant integration

### DIFF
--- a/.claude/commands/commit-and-pr.md
+++ b/.claude/commands/commit-and-pr.md
@@ -1,0 +1,1 @@
+Let's commit the changes. Run tests, typechecks, and format checks. Then commit, push, and create a pull request.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,36 @@
+name: Claude PR Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude-code-action:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude PR Action
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          timeout_minutes: "60"


### PR DESCRIPTION
## Summary
- Add Claude command for commit and PR workflow
- Add GitHub Actions workflow for Claude PR assistant integration
- Enable @claude mentions in issues, PR comments, and reviews

## Test plan
- [ ] Verify GitHub workflow triggers on @claude mentions
- [ ] Test Claude command functionality
- [ ] Confirm proper permissions and API key configuration

🤖 Generated with [Claude Code](https://claude.ai/code)