### PR TITLE
feat: switch the frontend from mock data to real collections api

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,6 +46,7 @@
     "react-day-picker": "^9.8.1",
     "react-dom": "^19.1.0",
     "recharts": "2.15.4",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "vaul": "^1.1.2"
   },

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       recharts:
         specifier: 2.15.4
         version: 2.15.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -2883,6 +2886,12 @@ packages:
   sirv@3.0.1:
     resolution: {integrity: sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==}
     engines: {node: '>=18'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   sorted-btree@1.8.1:
     resolution: {integrity: sha512-395+XIP+wqNn3USkFSrNz7G3Ss/MXlZEqesxvzCRFwL14h6e8LukDHdLBePn5pwbm5OQ9vGu8mDyz2lLDIqamQ==}
@@ -6039,6 +6048,11 @@ snapshots:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
       totalist: 3.0.1
+
+  sonner@2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   sorted-btree@1.8.1: {}
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { LoginPage } from '@/pages/AuthPage'
 import { NavigationContext } from '@/hooks/useNavigation'
 import { NavigationCommandDialog } from '@/components/NavigationCommandDialog'
 import { AppSidebar } from '@/components/AppSidebar'
+import { Toaster } from '@/components/ui/sonner'
 
 const queryClient = new QueryClient()
 
@@ -31,6 +32,7 @@ function App() {
           </SidebarInset>
         </SidebarProvider>
         <NavigationCommandDialog />
+        <Toaster />
       </NavigationContext.Provider>
     </QueryClientProvider>
   )

--- a/frontend/src/components/AddModsDialog.tsx
+++ b/frontend/src/components/AddModsDialog.tsx
@@ -1,0 +1,179 @@
+import { useState, useEffect } from 'react'
+import { IconSearch, IconPlus } from '@tabler/icons-react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { mods } from '@/services'
+import type { ModSubscription } from '@/types/api'
+import { handleApiError } from '@/lib/error-handler'
+
+interface AddModsDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onAddMods: (modIds: number[]) => void
+  existingModIds: number[]
+  collectionName: string
+}
+
+export function AddModsDialog({
+  open,
+  onOpenChange,
+  onAddMods,
+  existingModIds,
+  collectionName,
+}: AddModsDialogProps) {
+  const [availableMods, setAvailableMods] = useState<ModSubscription[]>([])
+  const [selectedModIds, setSelectedModIds] = useState<number[]>([])
+  const [searchQuery, setSearchQuery] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  // Load available mods when dialog opens
+  useEffect(() => {
+    if (open) {
+      loadAvailableMods()
+    }
+  }, [open])
+
+  const loadAvailableMods = async () => {
+    setLoading(true)
+    try {
+      const modSubscriptions = await mods.getModSubscriptions()
+      setAvailableMods(modSubscriptions)
+    } catch (error) {
+      handleApiError(error, 'Failed to load available mods')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // Filter mods that aren't already in the collection
+  const filteredMods = availableMods
+    .filter((mod) => !existingModIds.includes(mod.steam_id))
+    .filter((mod) => (mod.name || '').toLowerCase().includes(searchQuery.toLowerCase()))
+
+  const handleToggleMod = (modId: number) => {
+    setSelectedModIds((prev) =>
+      prev.includes(modId) ? prev.filter((id) => id !== modId) : [...prev, modId]
+    )
+  }
+
+  const handleAddMods = () => {
+    onAddMods(selectedModIds)
+    setSelectedModIds([])
+    setSearchQuery('')
+    onOpenChange(false)
+  }
+
+  const handleOpenChange = (newOpen: boolean) => {
+    if (!newOpen) {
+      setSelectedModIds([])
+      setSearchQuery('')
+    }
+    onOpenChange(newOpen)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="text-base">Add Mods to {collectionName}</DialogTitle>
+          <DialogDescription className="text-sm">
+            Select mods from your subscriptions to add to this collection.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Search input */}
+          <div className="relative">
+            <IconSearch className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="Search mods..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="pl-10 h-8 text-sm"
+            />
+          </div>
+
+          {/* Mods list */}
+          <div className="border rounded-md">
+            <div className="h-80 overflow-y-auto">
+              {loading ? (
+                <div className="flex items-center justify-center h-32">
+                  <p className="text-sm text-muted-foreground">Loading mods...</p>
+                </div>
+              ) : filteredMods.length === 0 ? (
+                <div className="flex items-center justify-center h-32">
+                  <p className="text-sm text-muted-foreground">
+                    {searchQuery ? 'No mods match your search' : 'No available mods to add'}
+                  </p>
+                </div>
+              ) : (
+                <div className="p-2 space-y-1">
+                  {filteredMods.map((mod) => (
+                    <div
+                      key={mod.steam_id}
+                      className="flex items-center gap-3 p-3 rounded-md hover:bg-muted/50 transition-colors"
+                    >
+                      <Checkbox
+                        checked={selectedModIds.includes(mod.steam_id)}
+                        onCheckedChange={() => handleToggleMod(mod.steam_id)}
+                        className="h-4 w-4"
+                      />
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm font-medium truncate">
+                            {mod.name || `Mod ${mod.steam_id}`}
+                          </span>
+                          <div className="flex items-center gap-1">
+                            {mod.type === 'mod' && (
+                              <Badge variant="outline" className="h-4 px-1 text-xs">
+                                Mod
+                              </Badge>
+                            )}
+                            {mod.type === 'mission' && (
+                              <Badge variant="outline" className="h-4 px-1 text-xs">
+                                Mission
+                              </Badge>
+                            )}
+                            {mod.type === 'map' && (
+                              <Badge variant="outline" className="h-4 px-1 text-xs">
+                                Map
+                              </Badge>
+                            )}
+                          </div>
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          Steam ID: {mod.steam_id}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button size="sm" onClick={handleAddMods} disabled={selectedModIds.length === 0}>
+            <IconPlus className="h-3 w-3 mr-1" />
+            Add {selectedModIds.length} Mod{selectedModIds.length !== 1 ? 's' : ''}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/CollectionHeader.tsx
+++ b/frontend/src/components/CollectionHeader.tsx
@@ -74,13 +74,13 @@ export function CollectionHeader({
           <Badge variant="outline" className="h-6 px-2 text-xs">
             {collection.mods.length} mods
           </Badge>
-          {collection.mods.some((m) => m.hasUpdate) && (
+          {collection.mods.some((m) => m.shouldUpdate) && (
             <Badge className="h-6 px-2 text-xs bg-orange-500/10 text-orange-600 border-orange-500/20">
-              {collection.mods.filter((m) => m.hasUpdate).length} updates
+              {collection.mods.filter((m) => m.shouldUpdate).length} updates
             </Badge>
           )}
         </div>
-        {collection.mods.some((mod) => mod.hasUpdate) && (
+        {collection.mods.some((mod) => mod.shouldUpdate) && (
           <Button size="sm" onClick={onUpdateAll} className="h-7 px-3 text-xs">
             Update All
           </Button>

--- a/frontend/src/components/CollectionItem.tsx
+++ b/frontend/src/components/CollectionItem.tsx
@@ -15,7 +15,7 @@ export function CollectionItem({
   onSelectCollection,
   onDeleteCollection,
 }: CollectionItemProps) {
-  const updateCount = collection.mods.filter((m) => m.hasUpdate).length
+  const updateCount = collection.mods.filter((m) => m.shouldUpdate).length
 
   return (
     <div className="group flex items-center gap-3 px-3 py-3 rounded-md border bg-card hover:bg-muted/30 transition-colors">

--- a/frontend/src/components/CollectionsCreateDialog.tsx
+++ b/frontend/src/components/CollectionsCreateDialog.tsx
@@ -14,14 +14,14 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
-import type { NewCollection, ModItem } from '@/types/collections'
+import type { CreateCollectionRequest } from '@/types/api'
 
 interface CreateCollectionDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
-  onCreate: (collection: NewCollection) => void
+  onCreate: (collection: CreateCollectionRequest) => void
   trigger?: React.ReactNode
-  selectedMods?: ModItem[]
+  selectedMods?: number[]
 }
 
 export function CreateCollectionDialog({
@@ -31,7 +31,7 @@ export function CreateCollectionDialog({
   trigger,
   selectedMods = [],
 }: CreateCollectionDialogProps) {
-  const [newCollection, setNewCollection] = useState<NewCollection>({
+  const [newCollection, setNewCollection] = useState<CreateCollectionRequest>({
     name: '',
     description: '',
   })
@@ -100,8 +100,8 @@ export function CreateCollectionDialog({
               <div className="max-h-32 overflow-y-auto border rounded-md p-2 bg-muted/50">
                 <div className="flex flex-wrap gap-1">
                   {selectedMods.map((mod) => (
-                    <Badge key={mod.id} variant="secondary" className="text-xs">
-                      {mod.name}
+                    <Badge key={mod} variant="secondary" className="text-xs">
+                      {mod}
                     </Badge>
                   ))}
                 </div>

--- a/frontend/src/components/CollectionsModsList.tsx
+++ b/frontend/src/components/CollectionsModsList.tsx
@@ -8,9 +8,10 @@ import type { ModItem } from '@/types/collections'
 interface ModsListProps {
   mods: ModItem[]
   collectionId: number
-  onToggleMod: (collectionId: number, modId: number) => void
+  onToggleMod: (collectionId: number, modId: number) => void // TODO: Remove when API supports mod disabling
   onUpdateMod: (mod: ModItem) => void
   onRemoveMod: (collectionId: number, modId: number, modName: string) => void
+  onAddMods: (collectionId: number) => void
 }
 
 export function ModsList({
@@ -19,13 +20,17 @@ export function ModsList({
   onToggleMod,
   onUpdateMod,
   onRemoveMod,
+  onAddMods,
 }: ModsListProps) {
+  // Feature flag for mod disabling - set to true when API supports it
+  const MOD_DISABLING_ENABLED = false // TODO: Enable when API supports mod disabling
+
   if (mods.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-64 text-center">
         <IconFolder className="h-12 w-12 text-muted-foreground/30 mb-3" />
         <p className="text-sm text-muted-foreground mb-3">No mods in this collection</p>
-        <Button size="sm">
+        <Button size="sm" onClick={() => onAddMods(collectionId)}>
           <IconPlus className="h-3 w-3 mr-1" />
           Add Mods
         </Button>
@@ -39,26 +44,29 @@ export function ModsList({
         <div
           key={mod.id}
           className={`group flex items-center gap-3 px-3 py-2 rounded-md border bg-card hover:bg-muted/30 transition-colors ${
-            mod.disabled ? 'opacity-50' : ''
+            MOD_DISABLING_ENABLED && mod.disabled ? 'opacity-50' : ''
           }`}
         >
-          <Checkbox
-            checked={!mod.disabled}
-            onCheckedChange={() => onToggleMod(collectionId, mod.id)}
-            className="h-4 w-4"
-          />
+          {/* TODO: Remove conditional when API supports mod disabling */}
+          {MOD_DISABLING_ENABLED && (
+            <Checkbox
+              checked={!mod.disabled}
+              onCheckedChange={() => onToggleMod(collectionId, mod.id)}
+              className="h-4 w-4"
+            />
+          )}
 
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2">
               <span
                 className={`text-sm font-medium truncate ${
-                  mod.disabled ? 'line-through text-muted-foreground' : ''
+                  MOD_DISABLING_ENABLED && mod.disabled ? 'line-through text-muted-foreground' : ''
                 }`}
               >
                 {mod.name}
               </span>
               <div className="flex items-center gap-1">
-                {mod.hasUpdate && <div className="h-1.5 w-1.5 rounded-full bg-orange-500" />}
+                {mod.shouldUpdate && <div className="h-1.5 w-1.5 rounded-full bg-orange-500" />}
                 {mod.isServerMod && (
                   <Badge variant="outline" className="h-4 px-1 text-xs">
                     S
@@ -67,14 +75,14 @@ export function ModsList({
               </div>
             </div>
             <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <span>v{mod.version}</span>
+              <span>v{mod.lastUpdated}</span>
               <span>•</span>
               <span>{mod.size}</span>
             </div>
           </div>
 
           <div className="flex items-center gap-1">
-            {mod.hasUpdate && (
+            {mod.shouldUpdate && (
               <Button size="sm" onClick={() => onUpdateMod(mod)} className="h-6 px-2 text-xs">
                 Update
               </Button>

--- a/frontend/src/components/UpdatingModCard.tsx
+++ b/frontend/src/components/UpdatingModCard.tsx
@@ -16,22 +16,20 @@ export function UpdatingModCard({ mod, onCancel, onDismiss }: UpdatingModCardPro
     return 'Updating...'
   }
 
-  const isCompleted = mod.status === 'completed' || mod.status === 'error'
+  const isCompleted = mod.progress === 100
 
   return (
     <div className="flex items-center gap-4 p-4 border rounded-lg bg-background shadow-lg min-w-80">
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 mb-1">
           <span className="font-medium truncate">{mod.name}</span>
-          <Badge variant={mod.status === 'error' ? 'destructive' : 'secondary'} className="text-xs">
+          <Badge variant={isCompleted ? 'secondary' : 'secondary'} className="text-xs">
             {getStatusText()}
           </Badge>
         </div>
         <div className="text-sm text-muted-foreground mb-2">{mod.version && `v${mod.version}`}</div>
 
         {!isCompleted && <Progress value={mod.progress} className="h-2" />}
-
-        {mod.error && <div className="text-sm text-destructive mt-1">{mod.error}</div>}
       </div>
 
       <div className="flex items-center gap-1">

--- a/frontend/src/components/ui/sonner.tsx
+++ b/frontend/src/components/ui/sonner.tsx
@@ -1,0 +1,21 @@
+import { Toaster as Sonner, ToasterProps } from 'sonner'
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  return (
+    <Sonner
+      theme="system"
+      className="toaster group"
+      closeButton
+      style={
+        {
+          '--normal-bg': 'var(--popover)',
+          '--normal-text': 'var(--popover-foreground)',
+          '--normal-border': 'var(--border)',
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/frontend/src/lib/error-handler.ts
+++ b/frontend/src/lib/error-handler.ts
@@ -1,0 +1,87 @@
+import { AxiosError } from 'axios'
+import { toast } from 'sonner'
+
+export interface ApiError {
+  message: string
+  status?: number
+  code?: string
+  details?: unknown
+}
+
+const HTTP_ERROR_MESSAGES = {
+  400: 'Bad request - please check your input',
+  401: 'Authentication required',
+  403: 'Permission denied',
+  404: 'Resource not found',
+  409: 'Conflict - resource already exists',
+  422: 'Validation error - please check your input',
+  429: 'Too many requests - please try again later',
+  500: 'Server error - please try again later',
+  502: 'Service unavailable - please try again later',
+  503: 'Service temporarily unavailable',
+} as const
+
+const DEFAULT_ERROR_MESSAGE = 'An unknown error occurred'
+
+export const extractErrorMessage = (error: unknown): string => {
+  if (error instanceof AxiosError) {
+    // Check if the response has a specific error message
+    const responseMessage = error.response?.data?.message || error.response?.data?.error
+    if (responseMessage) {
+      return responseMessage
+    }
+
+    // Fallback to generic HTTP error messages
+    const status = error.response?.status as keyof typeof HTTP_ERROR_MESSAGES
+    return HTTP_ERROR_MESSAGES[status] || error.message || DEFAULT_ERROR_MESSAGE
+  }
+
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  return DEFAULT_ERROR_MESSAGE
+}
+
+export const createApiError = (error: unknown): ApiError => {
+  const message = extractErrorMessage(error)
+
+  if (error instanceof AxiosError) {
+    return {
+      message,
+      status: error.response?.status,
+      code: error.code,
+      details: error.response?.data,
+    }
+  }
+
+  return { message }
+}
+
+export const handleApiError = (error: unknown, customMessage?: string): void => {
+  const apiError = createApiError(error)
+  const message = customMessage || apiError.message
+
+  toast.error(message, {
+    richColors: true,
+    description: apiError.status ? `Error ${apiError.status}` : undefined,
+    duration: 4000,
+  })
+
+  // Log error for debugging
+  console.error('API Error:', apiError)
+}
+
+export const showSuccessToast = (message: string, description?: string): void => {
+  toast.success(message, {
+    description,
+    duration: 3000,
+  })
+}
+
+export const showInfoToast = (message: string, description?: string): void => {
+  toast.info(message, {
+    description,
+    duration: 4000,
+  })
+}

--- a/frontend/src/lib/mock-data.ts
+++ b/frontend/src/lib/mock-data.ts
@@ -1278,30 +1278,31 @@ export const mockCollectionsService = {
     return { ...mockCollections[collectionIndex] }
   },
 
-  toggleModInCollection: async (
-    collectionId: number,
-    modId: number,
-    disabled: boolean
-  ): Promise<CollectionResponse> => {
-    await simulateNetworkDelay()
-    console.log(`🎭 Mock API: Toggling mod ${modId} in collection ${collectionId}`, {
-      disabled,
-    })
+  // TODO: Remove when API supports mod disabling
+  // toggleModInCollection: async (
+  //   collectionId: number,
+  //   modId: number,
+  //   disabled: boolean
+  // ): Promise<CollectionResponse> => {
+  //   await simulateNetworkDelay()
+  //   console.log(`🎭 Mock API: Toggling mod ${modId} in collection ${collectionId}`, {
+  //     disabled,
+  //   })
 
-    const collectionIndex = mockCollections.findIndex((c) => c.id === collectionId)
-    if (collectionIndex === -1) {
-      throw new Error(`Collection with id ${collectionId} not found`)
-    }
+  //   const collectionIndex = mockCollections.findIndex((c) => c.id === collectionId)
+  //   if (collectionIndex === -1) {
+  //     throw new Error(`Collection with id ${collectionId} not found`)
+  //   }
 
-    const modIndex = mockCollections[collectionIndex].mods.findIndex((m) => m.id === modId)
-    if (modIndex === -1) {
-      throw new Error(`Mod with id ${modId} not found in collection`)
-    }
+  //   const modIndex = mockCollections[collectionIndex].mods.findIndex((m) => m.id === modId)
+  //   if (modIndex === -1) {
+  //     throw new Error(`Mod with id ${modId} not found in collection`)
+  //   }
 
-    mockCollections[collectionIndex].mods[modIndex].disabled = disabled
+  //   mockCollections[collectionIndex].mods[modIndex].disabled = disabled
 
-    return { ...mockCollections[collectionIndex] }
-  },
+  //   return { ...mockCollections[collectionIndex] }
+  // },
 }
 
 // Mock Server Service

--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -8,6 +8,7 @@ import { UpdatingModCard } from '@/components/UpdatingModCard'
 import { useCollections } from '@/hooks/useCollections'
 import { CreateCollectionDialog } from '@/components/CollectionsCreateDialog'
 import { RemoveModDialog } from '@/components/CollectionsRemoveModDialog'
+import { AddModsDialog } from '@/components/AddModsDialog'
 import { ModsList } from '@/components/CollectionsModsList'
 import { CollectionsList } from '@/components/CollectionsList'
 import type { ModToRemove } from '@/types/collections'
@@ -23,6 +24,7 @@ export function CollectionManager() {
     deleteCollection,
     toggleMod,
     removeModFromCollection,
+    addModsToCollection,
     updateMod,
     updateAllMods,
     setActive,
@@ -32,6 +34,7 @@ export function CollectionManager() {
 
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
   const [isRemoveDialogOpen, setIsRemoveDialogOpen] = useState(false)
+  const [isAddModsDialogOpen, setIsAddModsDialogOpen] = useState(false)
   const [modToRemove, setModToRemove] = useState<ModToRemove | null>(null)
 
   const handleCreateCollection = (newCollection: { name: string; description: string }) => {
@@ -55,6 +58,15 @@ export function CollectionManager() {
     setIsRemoveDialogOpen(false)
   }
 
+  const handleAddMods = (_collectionId: number) => {
+    setIsAddModsDialogOpen(true)
+  }
+
+  const handleAddModsToCollection = (modIds: number[]) => {
+    if (!selectedCollection) return
+    addModsToCollection(selectedCollection.id, modIds)
+  }
+
   if (selectedCollection) {
     return (
       <div className="h-screen flex flex-col bg-background">
@@ -70,7 +82,7 @@ export function CollectionManager() {
             ]}
             actions={
               <>
-                {selectedCollection.mods.some((mod) => mod.hasUpdate) && (
+                {selectedCollection.mods.some((mod) => mod.shouldUpdate) && (
                   <Button size="sm" onClick={updateAllMods} className="h-7 px-3 text-xs">
                     Update All
                   </Button>
@@ -85,10 +97,17 @@ export function CollectionManager() {
                     Set Active
                   </Button>
                 )}
-                <Button variant="outline" size="sm" className="h-7 px-3 text-xs">
-                  <IconPlus className="h-3 w-3 mr-1" />
-                  Add
-                </Button>
+                {selectedCollection.mods.length > 0 && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 px-3 text-xs"
+                    onClick={() => handleAddMods(selectedCollection.id)}
+                  >
+                    <IconPlus className="h-3 w-3 mr-1" />
+                    Add
+                  </Button>
+                )}
               </>
             }
           />
@@ -101,6 +120,7 @@ export function CollectionManager() {
             onToggleMod={toggleMod}
             onUpdateMod={updateMod}
             onRemoveMod={handleRemoveModFromCollection}
+            onAddMods={handleAddMods}
           />
         </div>
 
@@ -122,6 +142,14 @@ export function CollectionManager() {
           onOpenChange={setIsRemoveDialogOpen}
           modToRemove={modToRemove}
           onConfirm={confirmRemoveMod}
+        />
+
+        <AddModsDialog
+          open={isAddModsDialogOpen}
+          onOpenChange={setIsAddModsDialogOpen}
+          onAddMods={handleAddModsToCollection}
+          existingModIds={selectedCollection.mods.map((mod) => mod.id)}
+          collectionName={selectedCollection.name}
         />
       </div>
     )

--- a/frontend/src/providers/db-provider.tsx
+++ b/frontend/src/providers/db-provider.tsx
@@ -5,6 +5,10 @@ import {
   serverConfigCollection,
   modsCollection,
 } from '@/lib/db-config'
+import type { Collection } from '@/types/collections'
+import type { Collection as TanStackCollection } from '@tanstack/react-db'
+import type { ServerConfigResponse, ServerStatusResponse } from '@/types/api'
+import type { ModSubscription } from '@/types/api'
 
 // Create DB context with all collections
 const DBContext = createContext({
@@ -15,7 +19,7 @@ const DBContext = createContext({
 })
 
 // Custom hook to use the collections
-export function useCollectionsDB() {
+export function useCollectionsDB(): TanStackCollection<Collection> {
   const context = useContext(DBContext)
   if (!context) {
     throw new Error('useCollectionsDB must be used within a DBProvider')
@@ -24,7 +28,7 @@ export function useCollectionsDB() {
 }
 
 // Custom hook to use the server collection
-export function useServerDB() {
+export function useServerDB(): TanStackCollection<ServerStatusResponse> {
   const context = useContext(DBContext)
   if (!context) {
     throw new Error('useServerDB must be used within a DBProvider')
@@ -33,7 +37,7 @@ export function useServerDB() {
 }
 
 // Custom hook to use the server config collection
-export function useServerConfigDB() {
+export function useServerConfigDB(): TanStackCollection<ServerConfigResponse> {
   const context = useContext(DBContext)
   if (!context) {
     throw new Error('useServerConfigDB must be used within a DBProvider')
@@ -42,7 +46,7 @@ export function useServerConfigDB() {
 }
 
 // Custom hook to use the mods collection
-export function useModsDB() {
+export function useModsDB(): TanStackCollection<ModSubscription> {
   const context = useContext(DBContext)
   if (!context) {
     throw new Error('useModsDB must be used within a DBProvider')

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import { handleApiError } from '@/lib/error-handler'
 
 // API base configuration
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api'
@@ -31,11 +32,16 @@ api.interceptors.request.use(
 api.interceptors.response.use(
   (response) => response,
   (error) => {
+    // Handle authentication errors
     if (error.response?.status === 401) {
-      // Handle unauthorized errors
       localStorage.removeItem('auth_token')
       window.location.href = '/login'
+      return Promise.reject(error)
     }
+
+    // Show error toast for other errors
+    handleApiError(error)
+
     return Promise.reject(error)
   }
 )

--- a/frontend/src/services/collections.service.ts
+++ b/frontend/src/services/collections.service.ts
@@ -9,45 +9,52 @@ import type {
   UpdateCollectionResponse,
   AddModToCollectionRequest,
   RemoveModFromCollectionRequest,
+  AddModToCollectionResponse,
+  RemoveModFromCollectionResponse,
 } from '@/types/api'
 
 // Collections API endpoints
 export const collectionsService = {
   // Get all collections
   getCollections: async (): Promise<CollectionResponse[]> => {
-    const response = await api.get<CollectionsListResponse>('/collections')
+    const response = await api.get<CollectionsListResponse>('/arma3/mod/collections')
     return response.data.results
   },
 
   // Get specific collection details
   getCollection: async (collectionId: number): Promise<CollectionResponse> => {
-    const response = await api.get<CollectionDetailsResponse>(`/collections/${collectionId}`)
+    const response = await api.get<CollectionDetailsResponse>(
+      `/arma3/mod/collection/${collectionId}`
+    )
     return response.data.results
   },
 
   // Create new collection
   createCollection: async (
     collectionData: CreateCollectionRequest
-  ): Promise<CollectionResponse> => {
-    const response = await api.post<CreateCollectionResponse>('/collections', collectionData)
-    return response.data.results
+  ): Promise<CreateCollectionResponse> => {
+    const response = await api.post<CreateCollectionResponse>(
+      '/arma3/mod/collection',
+      collectionData
+    )
+    return response.data
   },
 
   // Update collection
   updateCollection: async (
     collectionId: number,
     updateData: UpdateCollectionRequest
-  ): Promise<CollectionResponse> => {
+  ): Promise<UpdateCollectionResponse> => {
     const response = await api.patch<UpdateCollectionResponse>(
-      `/collections/${collectionId}`,
+      `/arma3/mod/collection/${collectionId}`,
       updateData
     )
-    return response.data.results
+    return response.data
   },
 
   // Delete collection
   deleteCollection: async (collectionId: number): Promise<{ message: string }> => {
-    const response = await api.delete<{ message: string }>(`/collections/${collectionId}`)
+    const response = await api.delete<{ message: string }>(`/arma3/mod/collection/${collectionId}`)
     return response.data
   },
 
@@ -55,35 +62,36 @@ export const collectionsService = {
   addModsToCollection: async (
     collectionId: number,
     modData: AddModToCollectionRequest
-  ): Promise<CollectionResponse> => {
-    const response = await api.post<UpdateCollectionResponse>(
-      `/collections/${collectionId}/mods`,
+  ): Promise<AddModToCollectionResponse> => {
+    const response = await api.patch<AddModToCollectionResponse>(
+      `/arma3/mod/collection/${collectionId}/mods`,
       modData
     )
-    return response.data.results
+    return response.data
   },
 
   // Remove mod from collection
   removeModFromCollection: async (
     collectionId: number,
-    modData: RemoveModFromCollectionRequest
-  ): Promise<CollectionResponse> => {
-    const response = await api.delete<UpdateCollectionResponse>(
-      `/collections/${collectionId}/mods/${modData.modId}`
+    params: RemoveModFromCollectionRequest
+  ): Promise<RemoveModFromCollectionResponse> => {
+    const response = await api.delete<RemoveModFromCollectionResponse>(
+      `/arma3/mod/collection/${collectionId}/mods`,
+      { data: params }
     )
-    return response.data.results
+    return response.data
   },
 
-  // Toggle mod in collection
-  toggleModInCollection: async (
-    collectionId: number,
-    modId: number,
-    disabled: boolean
-  ): Promise<CollectionResponse> => {
-    const response = await api.patch<UpdateCollectionResponse>(
-      `/collections/${collectionId}/mods/${modId}`,
-      { disabled }
-    )
-    return response.data.results
-  },
+  // // Toggle mod in collection
+  // toggleModInCollection: async (
+  //   collectionId: number,
+  //   modId: number,
+  //   disabled: boolean
+  // ): Promise<ToggleModInCollectionResponse> => {
+  //   const response = await api.patch<ToggleModInCollectionResponse>(
+  //     `/collections/${collectionId}/mods/${modId}`,
+  //     { disabled }
+  //   )
+  //   return response.data
+  // },
 }

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -5,16 +5,30 @@ import {
   mockModService,
   mockScheduleService,
 } from '@/lib/mock-data'
-import { collectionsService } from './collections.service.ts'
-import { serverService } from './server.service.ts'
-import { modService } from './mods.service.ts'
-import { scheduleService } from './schedules.service.ts'
+import { collectionsService } from './collections.service'
+import { serverService } from './server.service'
+import { modService } from './mods.service'
+import { scheduleService } from './schedules.service'
 
-// Simple service factory - exports real or mock services based on environment
-export const collections = USE_MOCK_DATA ? mockCollectionsService : collectionsService
-export const server = USE_MOCK_DATA ? mockServerService : serverService
-export const mods = USE_MOCK_DATA ? mockModService : modService
-export const schedules = USE_MOCK_DATA ? mockScheduleService : scheduleService
+// Per-endpoint mock data control
+const USE_MOCK_COLLECTIONS =
+  import.meta.env.VITE_USE_MOCK_COLLECTIONS === 'true' ||
+  (USE_MOCK_DATA && import.meta.env.VITE_USE_MOCK_COLLECTIONS !== 'false')
+const USE_MOCK_SERVER =
+  import.meta.env.VITE_USE_MOCK_SERVER === 'true' ||
+  (USE_MOCK_DATA && import.meta.env.VITE_USE_MOCK_SERVER !== 'false')
+const USE_MOCK_MODS =
+  import.meta.env.VITE_USE_MOCK_MODS === 'true' ||
+  (USE_MOCK_DATA && import.meta.env.VITE_USE_MOCK_MODS !== 'false')
+const USE_MOCK_SCHEDULES =
+  import.meta.env.VITE_USE_MOCK_SCHEDULES === 'true' ||
+  (USE_MOCK_DATA && import.meta.env.VITE_USE_MOCK_SCHEDULES !== 'false')
+
+// Service factory - exports real or mock services based on per-endpoint environment variables
+export const collections = USE_MOCK_COLLECTIONS ? mockCollectionsService : collectionsService
+export const server = USE_MOCK_SERVER ? mockServerService : serverService
+export const mods = USE_MOCK_MODS ? mockModService : modService
+export const schedules = USE_MOCK_SCHEDULES ? mockScheduleService : scheduleService
 
 // Re-export the API service for direct use
 export { api } from './api'

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -70,64 +70,88 @@ export interface AsyncJobSuccessResponse {
 }
 
 // Collections API types
-export interface CollectionResponse {
-  id: number
-  name: string
-  description: string
-  mods: ModItemResponse[]
-  createdAt: string
-  isActive: boolean
+export interface ModResponse {
+  readonly id: number
+  readonly steam_id: number
+  readonly filename: string
+  readonly name: string
+  readonly mod_type: string | null
+  readonly local_path: string
+  readonly arguments: string
+  readonly server_mod: boolean
+  readonly size_bytes: number
+  readonly last_updated: string | null
+  readonly steam_last_updated: string | null
+  readonly should_update: boolean
 }
 
-export interface ModItemResponse {
-  id: number
-  name: string
-  version?: string
-  size: string
-  type: 'mod' | 'mission' | 'map'
-  isServerMod: boolean
-  hasUpdate: boolean
-  disabled: boolean
+export interface ModCollectionEntryResponse {
+  readonly id: number
+  readonly collection_id: number
+  readonly mod_id: number
+  readonly added_at: string
+  readonly mod?: ModResponse
+}
+
+export interface CollectionResponse {
+  readonly id: number
+  readonly name: string
+  readonly description: string | null
+  readonly mod_count: number
+  readonly mods: ModCollectionEntryResponse[]
+  readonly created_at: string
+  readonly updated_at: string
 }
 
 export interface CollectionsListResponse {
-  results: CollectionResponse[]
-  message: string
+  readonly results: CollectionResponse[]
+  readonly message: string
 }
 
 export interface CollectionDetailsResponse {
-  results: CollectionResponse
-  message: string
+  readonly results: CollectionResponse
+  readonly message: string
 }
 
 export interface CreateCollectionRequest {
-  name: string
-  description: string
+  readonly name: string
+  readonly description: string
+  readonly mods?: number[] // Optional array of mod IDs
 }
 
 export interface CreateCollectionResponse {
-  results: CollectionResponse
-  message: string
+  readonly result: number // Returns the ID of created collection
+  readonly message: string
 }
 
 export interface UpdateCollectionRequest {
-  name?: string
-  description?: string
-  isActive?: boolean
-  mods?: ModItemResponse[]
+  readonly name?: string
+  readonly description?: string
+  readonly mods?: number[]
 }
 
 export interface UpdateCollectionResponse {
-  results: CollectionResponse
-  message: string
+  readonly message: string
 }
 
 export interface AddModToCollectionRequest {
-  modIds: number[]
+  readonly mods: number[]
+}
+
+export interface AddModToCollectionResponse {
+  readonly message: string
 }
 
 export interface RemoveModFromCollectionRequest {
-  modId: number
+  readonly mods: number[]
+}
+
+export interface RemoveModFromCollectionResponse {
+  readonly message: string
+}
+
+export interface DeleteCollectionResponse {
+  readonly message: string
 }
 
 // Server API types

--- a/frontend/src/types/collections.ts
+++ b/frontend/src/types/collections.ts
@@ -1,34 +1,41 @@
+// Frontend-specific types (local UI state)
 export interface ModItem {
-  id: number
-  name: string
-  version?: string
-  size: string
-  type: 'mod' | 'mission' | 'map'
-  isServerMod: boolean
-  hasUpdate: boolean
-  disabled: boolean
+  readonly id: number
+  readonly name: string
+  readonly version?: string
+  readonly size: string // Formatted size string (e.g. "150 MB")
+  readonly type: 'mod' | 'mission' | 'map'
+  readonly isServerMod: boolean
+  readonly shouldUpdate: boolean
+  readonly lastUpdated: string
+  readonly disabled: boolean
+  readonly sizeBytes: number // Raw bytes from API
 }
 
 export interface Collection {
-  id: number
+  readonly id: number
+  readonly createdAt: string
   name: string
   description: string
   mods: ModItem[]
-  createdAt: string
   isActive: boolean
 }
 
-// UpdatingMod is now imported from mods feature to avoid duplication
-export type { UpdatingMod } from '../mods/types'
-
-export interface ModToRemove {
-  collectionId: number
-  modId: number
-  modName: string
+export interface UpdatingMod {
+  readonly id: number
+  readonly name: string
+  readonly version?: string
+  readonly progress: number
 }
 
 export interface NewCollection {
-  name: string
-  description: string
-  mods?: ModItem[]
+  readonly name: string
+  readonly description: string
+  readonly mods?: ModItem[]
+}
+
+export interface ModToRemove {
+  readonly collectionId: number
+  readonly modId: number
+  readonly modName: string
 }

--- a/frontend/src/types/mods.ts
+++ b/frontend/src/types/mods.ts
@@ -27,6 +27,4 @@ export interface UpdatingMod {
   name: string
   version?: string
   progress: number
-  status: 'downloading' | 'installing' | 'verifying' | 'completed' | 'error'
-  error?: string
 }


### PR DESCRIPTION
## Changes

- switch frontend from using mock collections to use the actual backend api
- add uniform error handler toast so when collection requests fail it is displayed to the user
- fix discrepancies between backend request/response types and frontend types
- add support for adding mods to a collection