### PR TITLE
feat(backend): mod updates

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -80,6 +80,11 @@ def create_app(config_name: str | None = None) -> Flask:
             "schedule": crontab(minute=0, hour=6, day_of_month=1),
             "args": ["every_month"],
         },
+        "update_mod_metadata": {
+            "task": "app.tasks.background.update_mod_steam_updated_time",
+            "schedule": crontab(minute=0, hour="*"),  # hourly
+            "args": [],
+        },
     }
 
     # Register blueprints

--- a/backend/app/models/mod.py
+++ b/backend/app/models/mod.py
@@ -36,7 +36,8 @@ class Mod(db.Model):  # type: ignore[name-defined]
             e.g., "CBA_A3" becomes "@CBA_A3"
         name: Display name of the mod
         mod_type: Type of mod (mod, mission, map)
-        local_path: Local file system path, e.g. /home/user/server/arma3/addons/@CBA_A3
+        local_path: Local file system path, e.g. /home/user/server/arma3/addons/@CBA_A3.
+            Used to determine if the mod is downloaded or not. DO NOT MANUALLY EDIT.
         arguments: Command line arguments for server
         server_mod: Whether this is a server-side only mod
         size_bytes: Size of mod in bytes

--- a/backend/app/utils/helpers.py
+++ b/backend/app/utils/helpers.py
@@ -89,13 +89,14 @@ class Arma3ModManager:
                 disallowed_attrs = [
                     "id",
                     "updated_at",
+                    "steam_last_updated",
                 ]  # do not allow certain fields to be modified
                 for key, value in updated_data.items():
                     if key not in disallowed_attrs:
                         setattr(result, key, value)
                 db.session.commit()
         except Exception as e:
-            raise Exception("Failed to update mod (mod not found?)") from e
+            raise Exception(f"Failed to update mod (mod not found?): {str(e)}") from e
 
     def remove_subscribed_mod(self, mod_id: int) -> None:
         """


### PR DESCRIPTION
* improve mod update logic
* now runs a task every hour to check for mod updates on the steam side, updating the local record (but not mod) if there is an update
* the existing mod update task now checks for mods which are behind the latest steam version, instead of blindly updating all mods