### PR TITLE
feat: adds support for subscribing to mods via the UI and add mods to collections

### DIFF
--- a/frontend/src/components/CollectionsModsList.tsx
+++ b/frontend/src/components/CollectionsModsList.tsx
@@ -2,29 +2,16 @@ import { IconFolder, IconPlus, IconTrash } from '@tabler/icons-react'
 
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
-import { Checkbox } from '@/components/ui/checkbox'
 import type { ModSubscription } from '@/types/mods'
 
 interface ModsListProps {
   mods: ModSubscription[]
   collectionId: number
-  onToggleMod: (collectionId: number, modId: number) => void // TODO: Remove when API supports mod disabling
-  onUpdateMod: (mod: ModSubscription) => void
   onRemoveMod: (collectionId: number, modId: number, modName: string) => void
   onAddMods: (collectionId: number) => void
 }
 
-export function ModsList({
-  mods,
-  collectionId,
-  onToggleMod,
-  onUpdateMod,
-  onRemoveMod,
-  onAddMods,
-}: ModsListProps) {
-  // Feature flag for mod disabling - set to true when API supports it
-  const MOD_DISABLING_ENABLED = false // TODO: Enable when API supports mod disabling
-
+export function ModsList({ mods, collectionId, onRemoveMod, onAddMods }: ModsListProps) {
   if (mods.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-64 text-center">
@@ -45,15 +32,6 @@ export function ModsList({
           key={mod.id}
           className="group flex items-center gap-3 px-3 py-2 rounded-md border bg-card hover:bg-muted/30 transition-colors"
         >
-          {/* TODO: Remove conditional when API supports mod disabling */}
-          {MOD_DISABLING_ENABLED && (
-            <Checkbox
-              checked={true} // Always checked since mod disabling not supported yet
-              onCheckedChange={() => onToggleMod(collectionId, mod.id)}
-              className="h-4 w-4"
-            />
-          )}
-
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2">
               <span className="text-sm font-medium truncate">{mod.name}</span>
@@ -67,23 +45,16 @@ export function ModsList({
               </div>
             </div>
             <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <span>v{mod.lastUpdated || 'Unknown'}</span>
-              <span>•</span>
               <span>{mod.size}</span>
             </div>
           </div>
 
           <div className="flex items-center gap-1">
-            {mod.shouldUpdate && (
-              <Button size="sm" onClick={() => onUpdateMod(mod)} className="h-6 px-2 text-xs">
-                Update
-              </Button>
-            )}
             <Button
               variant="ghost"
               size="sm"
               onClick={() => onRemoveMod(collectionId, mod.id, mod.name)}
-              className="h-6 w-6 p-0 opacity-0 group-hover:opacity-100 transition-opacity hover:text-destructive"
+              className="h-6 w-6 p-0 hover:text-destructive"
             >
               <IconTrash className="h-3 w-3" />
             </Button>

--- a/frontend/src/components/ModsDataRowActions.tsx
+++ b/frontend/src/components/ModsDataRowActions.tsx
@@ -40,19 +40,22 @@ export function DataTableRowActions({
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-[160px]">
         {mod.shouldUpdate ? (
-          <DropdownMenuItem onClick={() => onUpdate(mod.id)} disabled={isLoading === 'updating'}>
+          <DropdownMenuItem
+            onClick={() => onUpdate(mod.steamId)}
+            disabled={isLoading === 'updating'}
+          >
             <IconRefresh className="mr-2 h-4 w-4" />
             {isLoading === 'updating' ? 'Updating...' : 'Update'}
           </DropdownMenuItem>
         ) : (
-          <DropdownMenuItem onClick={() => onDownload(mod.id)} disabled={!!isLoading}>
+          <DropdownMenuItem onClick={() => onDownload(mod.steamId)} disabled={!!isLoading}>
             <IconDownload className="mr-2 h-4 w-4" />
             Download
           </DropdownMenuItem>
         )}
         <DropdownMenuSeparator />
         <DropdownMenuItem
-          onClick={() => onDelete(mod.id)}
+          onClick={() => onDelete(mod.steamId)}
           disabled={isLoading === 'removing'}
           className="text-red-600"
         >

--- a/frontend/src/components/ModsSubscribeDialog.tsx
+++ b/frontend/src/components/ModsSubscribeDialog.tsx
@@ -1,0 +1,100 @@
+import { useState } from 'react'
+import { IconPlus } from '@tabler/icons-react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+interface ModsSubscribeDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSubscribe: (steamIds: number[]) => Promise<void> | void
+}
+
+export function ModsSubscribeDialog({ open, onOpenChange, onSubscribe }: ModsSubscribeDialogProps) {
+  const [inputValue, setInputValue] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  const parseSteamIds = (value: string): number[] => {
+    return value
+      .split(/[,\s]+/)
+      .map((v) => v.trim())
+      .filter(Boolean)
+      .map((v) => Number(v))
+      .filter((n) => Number.isFinite(n) && n > 0)
+  }
+
+  const handleSubscribe = async () => {
+    const steamIds = parseSteamIds(inputValue)
+    if (steamIds.length === 0) return
+
+    try {
+      setSubmitting(true)
+      await onSubscribe(steamIds)
+      setInputValue('')
+      onOpenChange(false)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      setInputValue('')
+      setSubmitting(false)
+    }
+    onOpenChange(next)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-base">Subscribe to Mods</DialogTitle>
+          <DialogDescription className="text-sm">
+            Enter one or more Steam Workshop IDs to subscribe. Separate with commas or spaces.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <Input
+            placeholder="e.g. 123456 987654, 13579"
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            className="h-9"
+          />
+          <p className="text-xs text-muted-foreground">
+            Tip: You can paste multiple IDs. We'll look up names automatically.
+          </p>
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onOpenChange(false)}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleSubscribe}
+            disabled={submitting || parseSteamIds(inputValue).length === 0}
+          >
+            <IconPlus className="h-3 w-3 mr-1" />
+            Subscribe{' '}
+            {parseSteamIds(inputValue).length > 0 ? `(${parseSteamIds(inputValue).length})` : ''}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/hooks/useMods.ts
+++ b/frontend/src/hooks/useMods.ts
@@ -136,8 +136,8 @@ export function useMods() {
     setUpdatingMods((prev) => [...prev, updatingMod])
 
     try {
-      // Start download job
-      const downloadResponse: ModDownloadResponse = await mods.downloadMod(steamId)
+      // Start download job (backend expects internal id)
+      const downloadResponse: ModDownloadResponse = await mods.downloadMod(mod.id)
       const jobId = downloadResponse.status
 
       // Poll job status
@@ -153,7 +153,8 @@ export function useMods() {
     if (!mod) return
 
     try {
-      const deleteResponse: ModDownloadResponse = await mods.deleteMod(steamId)
+      // Backend expects internal id for delete
+      const deleteResponse: ModDownloadResponse = await mods.deleteMod(mod.id)
       const jobId = deleteResponse.status
 
       // Poll job status

--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -22,10 +22,8 @@ export function CollectionManager() {
     setSelectedCollectionId,
     createCollection,
     deleteCollection,
-    toggleMod,
     removeModFromCollection,
     addModsToCollection,
-    updateMod,
     updateAllMods,
     setActive,
     cancelUpdate,
@@ -117,8 +115,6 @@ export function CollectionManager() {
           <ModsList
             mods={selectedCollection.mods}
             collectionId={selectedCollection.id}
-            onToggleMod={toggleMod}
-            onUpdateMod={updateMod}
             onRemoveMod={handleRemoveModFromCollection}
             onAddMods={handleAddMods}
           />

--- a/frontend/src/pages/ModsPage.tsx
+++ b/frontend/src/pages/ModsPage.tsx
@@ -3,14 +3,19 @@ import { useMods } from '@/hooks/useMods'
 import { UpdatingModCard } from '@/components/UpdatingModCard'
 import { DataTable } from '@/components/ModsDataTable'
 import { getColumns } from '@/components/ModsColumns'
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { IconPlus } from '@tabler/icons-react'
+import { ModsSubscribeDialog } from '@/components/ModsSubscribeDialog'
 import type { ExtendedModSubscription } from '@/types/mods'
-import type { NewCollection } from '@/types/collections'
+import type { CreateCollectionRequest } from '@/types/api'
 
 export function InstalledModsManager() {
   const {
     modSubscriptions,
     updatingMods,
     isLoading,
+    addModSubscription,
     downloadMod,
     removeModSubscription,
     cancelUpdate,
@@ -21,7 +26,7 @@ export function InstalledModsManager() {
   const mods: ExtendedModSubscription[] = modSubscriptions.map((mod) => ({
     ...mod,
     author: 'Community', // Default fallback
-    type: mod.type || 'mod', // Use type from API or default to 'mod'
+    type: mod.modType || 'mod', // Use type from API or default to 'mod'
     hasUpdate: Math.random() > 0.7, // Mock update status
     sizeOnDisk: `${Math.floor(Math.random() * 500 + 50)} MB`, // Mock size
   }))
@@ -34,7 +39,7 @@ export function InstalledModsManager() {
     await removeModSubscription(steamId)
   }
 
-  const handleCreateCollection = (collection: NewCollection) => {
+  const handleCreateCollection = (collection: CreateCollectionRequest) => {
     // TODO: Integrate with collections API
     console.log('Creating collection:', collection)
     // For now, just log the collection data
@@ -48,9 +53,23 @@ export function InstalledModsManager() {
     isLoading,
   })
 
+  // Subscribe dialog state and handler
+  const [subscribeOpen, setSubscribeOpen] = useState(false)
+  const handleSubscribeMods = async (steamIds: number[]) => {
+    for (const id of steamIds) {
+      await addModSubscription(id)
+    }
+  }
+
   return (
     <div className="space-y-4">
-      <PageTitle title="Installed Mods" description="Manage your installed content" />
+      <div className="flex items-center justify-between">
+        <PageTitle title="Installed Mods" description="Manage your installed content" />
+        <Button size="sm" onClick={() => setSubscribeOpen(true)}>
+          <IconPlus className="h-4 w-4 mr-1" />
+          Subscribe to Mods
+        </Button>
+      </div>
 
       {/* Show updating mods */}
       {updatingMods.length > 0 && (
@@ -70,6 +89,12 @@ export function InstalledModsManager() {
       )}
 
       <DataTable columns={columns} data={mods} onCreateCollection={handleCreateCollection} />
+
+      <ModsSubscribeDialog
+        open={subscribeOpen}
+        onOpenChange={setSubscribeOpen}
+        onSubscribe={handleSubscribeMods}
+      />
     </div>
   )
 }

--- a/frontend/src/types/mods.ts
+++ b/frontend/src/types/mods.ts
@@ -22,3 +22,11 @@ export interface UpdatingMod {
   readonly version?: string
   readonly progress: number
 }
+
+// Extended shape used by UI tables (optional fields for display/filtering)
+export interface ExtendedModSubscription extends ModSubscription {
+  readonly author?: string
+  readonly type?: 'mod' | 'mission' | 'map'
+  readonly hasUpdate?: boolean
+  readonly sizeOnDisk?: string
+}


### PR DESCRIPTION
## Changes

- Fixed a bug where I was using steamId when calling the API for mods when should be using mod ID
- Disables prompts to update and toggle mods as this is basically handled by the concept of subscriptions
- Adds dialog to subscribe to mods by providing their Steam ID
- Adds support for assigning a subscribed mod to a collection