### PR TITLE
fix: remove the concept of mod updating since we use subscriptions

### DIFF
--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -43,8 +43,8 @@ const data = {
       icon: IconFolder,
     },
     {
-      title: 'Installed',
-      url: 'mod-management',
+      title: 'Subscriptions',
+      url: 'mod-subscriptions',
       icon: IconPackage,
     },
   ],

--- a/frontend/src/components/CollectionHeader.tsx
+++ b/frontend/src/components/CollectionHeader.tsx
@@ -9,7 +9,6 @@ interface CollectionHeaderProps {
   collection: Collection
   onBack: () => void
   onTitleEdit: (title: string) => void
-  onUpdateAll: () => void
   onSetActive: () => void
   isEditingTitle: boolean
   editingTitle: string
@@ -22,7 +21,6 @@ interface CollectionHeaderProps {
 export function CollectionHeader({
   collection,
   onBack,
-  onUpdateAll,
   onSetActive,
   isEditingTitle,
   editingTitle,
@@ -74,17 +72,7 @@ export function CollectionHeader({
           <Badge variant="outline" className="h-6 px-2 text-xs">
             {collection.mods.length} mods
           </Badge>
-          {collection.mods.some((m) => m.shouldUpdate) && (
-            <Badge className="h-6 px-2 text-xs bg-orange-500/10 text-orange-600 border-orange-500/20">
-              {collection.mods.filter((m) => m.shouldUpdate).length} updates
-            </Badge>
-          )}
         </div>
-        {collection.mods.some((mod) => mod.shouldUpdate) && (
-          <Button size="sm" onClick={onUpdateAll} className="h-7 px-3 text-xs">
-            Update All
-          </Button>
-        )}
         {!collection.isActive && (
           <Button variant="outline" size="sm" onClick={onSetActive} className="h-7 px-3 text-xs">
             Set Active

--- a/frontend/src/components/CollectionItem.tsx
+++ b/frontend/src/components/CollectionItem.tsx
@@ -15,7 +15,6 @@ export function CollectionItem({
   onSelectCollection,
   onDeleteCollection,
 }: CollectionItemProps) {
-  const updateCount = collection.mods.filter((m) => m.shouldUpdate).length
 
   return (
     <div className="group flex items-center gap-3 px-3 py-3 rounded-md border bg-card hover:bg-muted/30 transition-colors">
@@ -30,11 +29,6 @@ export function CollectionItem({
             <Badge variant="outline" className="h-4 px-1 text-xs">
               {collection.mods.length} mods
             </Badge>
-            {updateCount > 0 && (
-              <Badge className="h-4 px-1 text-xs bg-orange-500/10 text-orange-600 border-orange-500/20">
-                {updateCount} updates
-              </Badge>
-            )}
           </div>
         </div>
         <p className="text-xs text-muted-foreground truncate">{collection.description}</p>

--- a/frontend/src/components/CollectionsModsList.tsx
+++ b/frontend/src/components/CollectionsModsList.tsx
@@ -36,7 +36,6 @@ export function ModsList({ mods, collectionId, onRemoveMod, onAddMods }: ModsLis
             <div className="flex items-center gap-2">
               <span className="text-sm font-medium truncate">{mod.name}</span>
               <div className="flex items-center gap-1">
-                {mod.shouldUpdate && <div className="h-1.5 w-1.5 rounded-full bg-orange-500" />}
                 {mod.isServerMod && (
                   <Badge variant="outline" className="h-4 px-1 text-xs">
                     S

--- a/frontend/src/components/MainContent.tsx
+++ b/frontend/src/components/MainContent.tsx
@@ -1,6 +1,6 @@
 import { ServerControlPanel } from '@/pages/ServerPage'
 import { ServerConfigEditor } from '@/components/ServerConfigEditor'
-import { InstalledModsManager } from '@/pages/ModsPage'
+import { SubscribedModsManager } from '@/pages/ModsPage'
 import { CollectionManager } from '@/pages/CollectionsPage'
 import { SchedulesManager } from '@/pages/SchedulesPage'
 import { Settings } from '@/pages/SettingsPage'
@@ -13,8 +13,8 @@ export function MainContent() {
     switch (currentPage) {
       case 'server-control':
         return <ServerControlPanel />
-      case 'mod-management':
-        return <InstalledModsManager />
+      case 'mod-subscriptions':
+        return <SubscribedModsManager />
       case 'collections':
         return <CollectionManager />
       case 'schedules':

--- a/frontend/src/components/ModsColumns.tsx
+++ b/frontend/src/components/ModsColumns.tsx
@@ -8,9 +8,7 @@ import { DataTableRowActions } from '@/components/ModsDataRowActions'
 import type { ModSubscription } from '@/types/mods.ts'
 
 interface GetColumnsProps {
-  onUpdate: (id: number) => Promise<void>
   onDelete: (id: number) => Promise<void>
-  onDownload: (id: number) => Promise<void>
   isLoading?: string | null
 }
 
@@ -41,127 +39,93 @@ const getTypeBadgeVariant = (type: ModSubscription['modType']) => {
 }
 
 export const getColumns = ({
-  onUpdate,
   onDelete,
-  onDownload,
   isLoading,
 }: GetColumnsProps): ColumnDef<ModSubscription>[] => [
-  {
-    id: 'select',
-    header: ({ table }) => (
-      <Checkbox
-        checked={
-          table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && 'indeterminate')
-        }
-        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
-        aria-label="Select all"
-      />
-    ),
-    cell: ({ row }) => (
-      <Checkbox
-        checked={row.getIsSelected()}
-        onCheckedChange={(value) => row.toggleSelected(!!value)}
-        aria-label="Select row"
-      />
-    ),
-    enableSorting: false,
-    enableHiding: false,
-  },
-  {
-    accessorKey: 'name',
-    header: ({ column }) => <DataTableColumnHeader column={column} title="Name" />,
-    cell: ({ row }) => {
-      const name = row.getValue('name') as string
-      const steamId = row.original.steamId
-      return (
-        <div className="max-w-[200px]">
-          <div className="font-medium">{name || `Mod ${steamId}`}</div>
-          <div className="text-xs text-muted-foreground">Steam ID: {steamId}</div>
-        </div>
-      )
+    {
+      id: 'select',
+      header: ({ table }) => (
+        <Checkbox
+          checked={
+            table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && 'indeterminate')
+          }
+          onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+          aria-label="Select all"
+        />
+      ),
+      cell: ({ row }) => (
+        <Checkbox
+          checked={row.getIsSelected()}
+          onCheckedChange={(value) => row.toggleSelected(!!value)}
+          aria-label="Select row"
+        />
+      ),
+      enableSorting: false,
+      enableHiding: false,
     },
-  },
-  {
-    accessorKey: 'author',
-    header: ({ column }) => <DataTableColumnHeader column={column} title="Author" />,
-    cell: ({ row }) => {
-      const author = row.getValue('author') as string
-      return (
-        <div className="flex items-center gap-2">
-          <IconUser className="h-3 w-3 text-muted-foreground" />
-          <span className="text-sm">{author || 'Unknown'}</span>
-        </div>
-      )
+    {
+      accessorKey: 'name',
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Name" />,
+      cell: ({ row }) => {
+        const name = row.getValue('name') as string
+        const steamId = row.original.steamId
+        return (
+          <div className="max-w-[200px]">
+            <div className="font-medium">{name || `Mod ${steamId}`}</div>
+            <div className="text-xs text-muted-foreground">Steam ID: {steamId}</div>
+          </div>
+        )
+      },
     },
-  },
-  {
-    accessorKey: 'type',
-    header: ({ column }) => <DataTableColumnHeader column={column} title="Type" />,
-    cell: ({ row }) => {
-      const type = row.getValue('modType') as ModSubscription['modType']
-      return (
-        <div className="flex items-center gap-2">
-          {getTypeIcon(type || 'mod')}
-          <Badge variant={getTypeBadgeVariant(type || 'mod')} className="text-xs">
-            {(type || 'mod').charAt(0).toUpperCase() + (type || 'mod').slice(1)}
-          </Badge>
-        </div>
-      )
+    {
+      accessorKey: 'author',
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Author" />,
+      cell: ({ row }) => {
+        const author = row.getValue('author') as string
+        return (
+          <div className="flex items-center gap-2">
+            <IconUser className="h-3 w-3 text-muted-foreground" />
+            <span className="text-sm">{author || 'Unknown'}</span>
+          </div>
+        )
+      },
     },
-    filterFn: (row, id, value) => {
-      return value.includes(row.getValue(id))
+    {
+      accessorKey: 'type',
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Type" />,
+      cell: ({ row }) => {
+        const type = row.getValue('modType') as ModSubscription['modType']
+        return (
+          <div className="flex items-center gap-2">
+            {getTypeIcon(type || 'mod')}
+            <Badge variant={getTypeBadgeVariant(type || 'mod')} className="text-xs">
+              {(type || 'mod').charAt(0).toUpperCase() + (type || 'mod').slice(1)}
+            </Badge>
+          </div>
+        )
+      },
+      filterFn: (row, id, value) => {
+        return value.includes(row.getValue(id))
+      },
     },
-  },
-  {
-    accessorKey: 'size',
-    header: ({ column }) => <DataTableColumnHeader column={column} title="Size" />,
-    cell: ({ row }) => {
-      const size = row.getValue('size') as string
-      return <div className="text-sm">{size || 'Unknown'}</div>
+    {
+      accessorKey: 'size',
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Size" />,
+      cell: ({ row }) => {
+        const size = row.getValue('size') as string
+        return <div className="text-sm">{size || 'Unknown'}</div>
+      },
     },
-  },
-  {
-    accessorKey: 'lastUpdated',
-    header: ({ column }) => <DataTableColumnHeader column={column} title="Last Updated" />,
-    cell: ({ row }) => {
-      const lastUpdated = row.getValue('lastUpdated') as string
-      if (!lastUpdated) return <div className="text-sm text-muted-foreground">—</div>
-
-      const date = new Date(lastUpdated)
-      return <div className="text-sm">{date.toLocaleDateString()}</div>
+    {
+      id: 'actions',
+      cell: ({ row }) => (
+        <DataTableRowActions
+          row={row}
+          onDelete={onDelete}
+          isLoading={isLoading}
+        />
+      ),
+      enableSorting: false,
+      enableHiding: false,
     },
-  },
-  {
-    accessorKey: 'shouldUpdate',
-    header: ({ column }) => <DataTableColumnHeader column={column} title="Status" />,
-    cell: ({ row }) => {
-      const hasUpdate = row.getValue('shouldUpdate') as boolean
-      return (
-        <Badge variant={hasUpdate ? 'destructive' : 'secondary'} className="text-xs">
-          {hasUpdate ? 'Update Available' : 'Up to Date'}
-        </Badge>
-      )
-    },
-    filterFn: (row, id, value) => {
-      const hasUpdate = row.getValue(id) as boolean
-      if (value === 'all') return true
-      if (value === 'updates') return hasUpdate
-      if (value === 'current') return !hasUpdate
-      return true
-    },
-  },
-  {
-    id: 'actions',
-    cell: ({ row }) => (
-      <DataTableRowActions
-        row={row}
-        onUpdate={onUpdate}
-        onDelete={onDelete}
-        onDownload={onDownload}
-        isLoading={isLoading}
-      />
-    ),
-    enableSorting: false,
-    enableHiding: false,
-  },
-]
+  ]

--- a/frontend/src/components/ModsDataRowActions.tsx
+++ b/frontend/src/components/ModsDataRowActions.tsx
@@ -1,13 +1,11 @@
 import { type Row } from '@tanstack/react-table'
 import { MoreHorizontal, Trash } from 'lucide-react'
-import { IconRefresh, IconDownload } from '@tabler/icons-react'
 
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 
@@ -15,17 +13,13 @@ import type { ModSubscription } from '@/types/mods'
 
 interface DataTableRowActionsProps {
   row: Row<ModSubscription>
-  onUpdate: (id: number) => Promise<void>
   onDelete: (id: number) => Promise<void>
-  onDownload: (id: number) => Promise<void>
   isLoading?: string | null
 }
 
 export function DataTableRowActions({
   row,
-  onUpdate,
   onDelete,
-  onDownload,
   isLoading,
 }: DataTableRowActionsProps) {
   const mod = row.original
@@ -39,21 +33,6 @@ export function DataTableRowActions({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-[160px]">
-        {mod.shouldUpdate ? (
-          <DropdownMenuItem
-            onClick={() => onUpdate(mod.steamId)}
-            disabled={isLoading === 'updating'}
-          >
-            <IconRefresh className="mr-2 h-4 w-4" />
-            {isLoading === 'updating' ? 'Updating...' : 'Update'}
-          </DropdownMenuItem>
-        ) : (
-          <DropdownMenuItem onClick={() => onDownload(mod.steamId)} disabled={!!isLoading}>
-            <IconDownload className="mr-2 h-4 w-4" />
-            Download
-          </DropdownMenuItem>
-        )}
-        <DropdownMenuSeparator />
         <DropdownMenuItem
           onClick={() => onDelete(mod.steamId)}
           disabled={isLoading === 'removing'}

--- a/frontend/src/components/ModsDataTable.tsx
+++ b/frontend/src/components/ModsDataTable.tsx
@@ -119,19 +119,6 @@ export function DataTable<TData, TValue>({
               <SelectItem value="map">Maps</SelectItem>
             </SelectContent>
           </Select>
-          <Select
-            value={(table.getColumn('shouldUpdate')?.getFilterValue() as string) ?? 'all'}
-            onValueChange={(value) => table.getColumn('shouldUpdate')?.setFilterValue(value)}
-          >
-            <SelectTrigger className="w-[180px]">
-              <SelectValue placeholder="Filter by status" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All Status</SelectItem>
-              <SelectItem value="updates">Updates Available</SelectItem>
-              <SelectItem value="current">Up to Date</SelectItem>
-            </SelectContent>
-          </Select>
         </div>
         <div className="flex items-center space-x-2">
           {hasSelectedMods && (

--- a/frontend/src/components/NavigationCommand.tsx
+++ b/frontend/src/components/NavigationCommand.tsx
@@ -42,8 +42,8 @@ const navigationData = {
       shortcut: '⌘O',
     },
     {
-      title: 'Installed',
-      url: 'mod-management',
+      title: 'Subscriptions',
+      url: 'mod-subscriptions',
       icon: IconPackage,
       shortcut: '⌘M',
     },

--- a/frontend/src/hooks/useCollections.ts
+++ b/frontend/src/hooks/useCollections.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useLiveQuery } from '@tanstack/react-db'
 import { useCollectionsDB } from '@/providers/db-provider'
-import type { Collection, UpdatingMod, NewCollection } from '@/types/collections'
+import type { Collection, NewCollection } from '@/types/collections'
 import type { ModSubscription } from '@/types/mods'
 
 export function useCollections() {
@@ -14,7 +14,6 @@ export function useCollections() {
 
   // Local state for UI-specific concerns
   const [selectedCollectionId, setSelectedCollectionId] = useState<number | null>(null)
-  const [updatingMods, setUpdatingMods] = useState<UpdatingMod[]>([])
 
   // Derive selectedCollection from collections array to keep it in sync
   const selectedCollection = selectedCollectionId
@@ -185,53 +184,6 @@ export function useCollections() {
     }
   }
 
-  const updateMod = async (mod: ModSubscription) => {
-    // Add mod to updating list
-    const updatingMod: UpdatingMod = {
-      id: mod.id,
-      name: mod.name,
-      version: mod.lastUpdated,
-      progress: 0,
-    }
-
-    setUpdatingMods((prev) => [...prev, updatingMod])
-
-    // Simulate update process (this would be replaced with real API calls)
-    const updateSteps = [
-      { status: 'downloading' as const, duration: 2000, progress: 50 },
-      { status: 'installing' as const, duration: 1500, progress: 80 },
-      { status: 'verifying' as const, duration: 1000, progress: 95 },
-      { status: 'completed' as const, duration: 500, progress: 100 },
-    ]
-
-    for (const step of updateSteps) {
-      await new Promise((resolve) => setTimeout(resolve, step.duration))
-
-      setUpdatingMods((prev) =>
-        prev.map((m) =>
-          m.id === mod.id ? { ...m, status: step.status, progress: step.progress } : m
-        )
-      )
-    }
-
-    // Invalidate collections to reflect the update
-    // queryClient.invalidateQueries({ queryKey: ['collections'] }); // This line was removed as per the edit hint
-
-    // Auto-dismiss after 3 seconds
-    setTimeout(() => {
-      setUpdatingMods((prev) => prev.filter((m) => m.id !== mod.id))
-    }, 3000)
-  }
-
-  const updateAllMods = async () => {
-    if (!selectedCollection) return
-
-    const modsWithUpdates = selectedCollection.mods.filter((mod) => mod.shouldUpdate)
-
-    for (const mod of modsWithUpdates) {
-      await updateMod(mod)
-    }
-  }
 
   const setActive = async (collectionId: number) => {
     try {
@@ -254,29 +206,17 @@ export function useCollections() {
     }
   }
 
-  const cancelUpdate = (modId: number) => {
-    setUpdatingMods((prev) => prev.filter((m) => m.id !== modId))
-  }
-
-  const dismissUpdate = (modId: number) => {
-    setUpdatingMods((prev) => prev.filter((m) => m.id !== modId))
-  }
 
   return {
     collections,
     selectedCollection,
-    updatingMods,
     setSelectedCollectionId,
     createCollection,
     deleteCollection,
     toggleMod,
     removeModFromCollection,
     addModsToCollection,
-    updateMod,
-    updateAllMods,
     setActive,
     updateCollectionName,
-    cancelUpdate,
-    dismissUpdate,
   }
 }

--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -3,7 +3,6 @@ import { IconPlus } from '@tabler/icons-react'
 
 import { Button } from '@/components/ui/button'
 import { PageTitle } from '@/components/PageTitle'
-import { UpdatingModCard } from '@/components/UpdatingModCard'
 
 import { useCollections } from '@/hooks/useCollections'
 import { CreateCollectionDialog } from '@/components/CollectionsCreateDialog'
@@ -18,16 +17,12 @@ export function CollectionManager() {
   const {
     collections,
     selectedCollection,
-    updatingMods,
     setSelectedCollectionId,
     createCollection,
     deleteCollection,
     removeModFromCollection,
     addModsToCollection,
-    updateAllMods,
     setActive,
-    cancelUpdate,
-    dismissUpdate,
   } = useCollections()
 
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
@@ -80,11 +75,6 @@ export function CollectionManager() {
             ]}
             actions={
               <>
-                {selectedCollection.mods.some((mod) => mod.shouldUpdate) && (
-                  <Button size="sm" onClick={updateAllMods} className="h-7 px-3 text-xs">
-                    Update All
-                  </Button>
-                )}
                 {!selectedCollection.isActive && (
                   <Button
                     variant="outline"
@@ -103,7 +93,7 @@ export function CollectionManager() {
                     onClick={() => handleAddMods(selectedCollection.id)}
                   >
                     <IconPlus className="h-3 w-3 mr-1" />
-                    Add
+                    New
                   </Button>
                 )}
               </>
@@ -119,19 +109,6 @@ export function CollectionManager() {
             onAddMods={handleAddMods}
           />
         </div>
-
-        {updatingMods.length > 0 && (
-          <div className="fixed bottom-4 right-4 space-y-2 z-50">
-            {updatingMods.map((mod) => (
-              <UpdatingModCard
-                key={mod.id}
-                mod={mod}
-                onCancel={cancelUpdate}
-                onDismiss={dismissUpdate}
-              />
-            ))}
-          </div>
-        )}
 
         <RemoveModDialog
           open={isRemoveDialogOpen}

--- a/frontend/src/pages/ModsPage.tsx
+++ b/frontend/src/pages/ModsPage.tsx
@@ -1,6 +1,5 @@
 import { PageTitle } from '@/components/PageTitle'
 import { useMods } from '@/hooks/useMods'
-import { UpdatingModCard } from '@/components/UpdatingModCard'
 import { DataTable } from '@/components/ModsDataTable'
 import { getColumns } from '@/components/ModsColumns'
 import { useState } from 'react'
@@ -10,30 +9,21 @@ import { ModsSubscribeDialog } from '@/components/ModsSubscribeDialog'
 import type { ExtendedModSubscription } from '@/types/mods'
 import type { CreateCollectionRequest } from '@/types/api'
 
-export function InstalledModsManager() {
+export function SubscribedModsManager() {
   const {
     modSubscriptions,
-    updatingMods,
     isLoading,
     addModSubscription,
-    downloadMod,
     removeModSubscription,
-    cancelUpdate,
-    dismissUpdate,
   } = useMods()
 
   // Transform mod subscriptions to match UI expectations
   const mods: ExtendedModSubscription[] = modSubscriptions.map((mod) => ({
     ...mod,
     author: 'Community', // Default fallback
-    type: mod.modType || 'mod', // Use type from API or default to 'mod'
-    hasUpdate: Math.random() > 0.7, // Mock update status
-    sizeOnDisk: `${Math.floor(Math.random() * 500 + 50)} MB`, // Mock size
+    type: mod.modType || 'mod', // Default fallback
+    sizeOnDisk: `Unknown`,
   }))
-
-  const handleUpdate = async (steamId: number) => {
-    await downloadMod(steamId)
-  }
 
   const handleDelete = async (steamId: number) => {
     await removeModSubscription(steamId)
@@ -47,9 +37,7 @@ export function InstalledModsManager() {
   }
 
   const columns = getColumns({
-    onUpdate: handleUpdate,
     onDelete: handleDelete,
-    onDownload: downloadMod,
     isLoading,
   })
 
@@ -64,29 +52,13 @@ export function InstalledModsManager() {
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <PageTitle title="Installed Mods" description="Manage your installed content" />
-        <Button size="sm" onClick={() => setSubscribeOpen(true)}>
+        <PageTitle title="Mod Subscriptions" description="Manage your installed content" />
+        <Button size="sm" className="h-7 px-3 text-xs" onClick={() => setSubscribeOpen(true)}>
           <IconPlus className="h-4 w-4 mr-1" />
-          Subscribe to Mods
+          New
         </Button>
       </div>
 
-      {/* Show updating mods */}
-      {updatingMods.length > 0 && (
-        <div className="space-y-2">
-          <h3 className="text-sm font-medium">Updating Mods</h3>
-          <div className="space-y-2">
-            {updatingMods.map((mod) => (
-              <UpdatingModCard
-                key={mod.id}
-                mod={mod}
-                onCancel={cancelUpdate}
-                onDismiss={dismissUpdate}
-              />
-            ))}
-          </div>
-        </div>
-      )}
 
       <DataTable columns={columns} data={mods} onCreateCollection={handleCreateCollection} />
 

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -13,7 +13,7 @@ import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as ServerControlRouteImport } from './routes/server-control'
 import { Route as ServerConfigsRouteImport } from './routes/server-configs'
 import { Route as SchedulesRouteImport } from './routes/schedules'
-import { Route as ModManagementRouteImport } from './routes/mod-management'
+import { Route as ModSubscriptionsRouteImport } from './routes/mod-subscriptions'
 import { Route as CollectionsRouteImport } from './routes/collections'
 import { Route as AuthRouteImport } from './routes/auth'
 import { Route as IndexRouteImport } from './routes/index'
@@ -38,9 +38,9 @@ const SchedulesRoute = SchedulesRouteImport.update({
   path: '/schedules',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ModManagementRoute = ModManagementRouteImport.update({
-  id: '/mod-management',
-  path: '/mod-management',
+const ModSubscriptionsRoute = ModSubscriptionsRouteImport.update({
+  id: '/mod-subscriptions',
+  path: '/mod-subscriptions',
   getParentRoute: () => rootRouteImport,
 } as any)
 const CollectionsRoute = CollectionsRouteImport.update({
@@ -63,7 +63,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/auth': typeof AuthRoute
   '/collections': typeof CollectionsRoute
-  '/mod-management': typeof ModManagementRoute
+  '/mod-subscriptions': typeof ModSubscriptionsRoute
   '/schedules': typeof SchedulesRoute
   '/server-configs': typeof ServerConfigsRoute
   '/server-control': typeof ServerControlRoute
@@ -73,7 +73,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/auth': typeof AuthRoute
   '/collections': typeof CollectionsRoute
-  '/mod-management': typeof ModManagementRoute
+  '/mod-subscriptions': typeof ModSubscriptionsRoute
   '/schedules': typeof SchedulesRoute
   '/server-configs': typeof ServerConfigsRoute
   '/server-control': typeof ServerControlRoute
@@ -84,7 +84,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/auth': typeof AuthRoute
   '/collections': typeof CollectionsRoute
-  '/mod-management': typeof ModManagementRoute
+  '/mod-subscriptions': typeof ModSubscriptionsRoute
   '/schedules': typeof SchedulesRoute
   '/server-configs': typeof ServerConfigsRoute
   '/server-control': typeof ServerControlRoute
@@ -96,7 +96,7 @@ export interface FileRouteTypes {
     | '/'
     | '/auth'
     | '/collections'
-    | '/mod-management'
+    | '/mod-subscriptions'
     | '/schedules'
     | '/server-configs'
     | '/server-control'
@@ -106,7 +106,7 @@ export interface FileRouteTypes {
     | '/'
     | '/auth'
     | '/collections'
-    | '/mod-management'
+    | '/mod-subscriptions'
     | '/schedules'
     | '/server-configs'
     | '/server-control'
@@ -116,7 +116,7 @@ export interface FileRouteTypes {
     | '/'
     | '/auth'
     | '/collections'
-    | '/mod-management'
+    | '/mod-subscriptions'
     | '/schedules'
     | '/server-configs'
     | '/server-control'
@@ -127,7 +127,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AuthRoute: typeof AuthRoute
   CollectionsRoute: typeof CollectionsRoute
-  ModManagementRoute: typeof ModManagementRoute
+  ModSubscriptionsRoute: typeof ModSubscriptionsRoute
   SchedulesRoute: typeof SchedulesRoute
   ServerConfigsRoute: typeof ServerConfigsRoute
   ServerControlRoute: typeof ServerControlRoute
@@ -164,11 +164,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SchedulesRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/mod-management': {
-      id: '/mod-management'
-      path: '/mod-management'
-      fullPath: '/mod-management'
-      preLoaderRoute: typeof ModManagementRouteImport
+    '/mod-subscriptions': {
+      id: '/mod-subscriptions'
+      path: '/mod-subscriptions'
+      fullPath: '/mod-subscriptions'
+      preLoaderRoute: typeof ModSubscriptionsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/collections': {
@@ -199,7 +199,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AuthRoute: AuthRoute,
   CollectionsRoute: CollectionsRoute,
-  ModManagementRoute: ModManagementRoute,
+  ModSubscriptionsRoute: ModSubscriptionsRoute,
   SchedulesRoute: SchedulesRoute,
   ServerConfigsRoute: ServerConfigsRoute,
   ServerControlRoute: ServerControlRoute,

--- a/frontend/src/routes/mod-management.tsx
+++ b/frontend/src/routes/mod-management.tsx
@@ -1,6 +1,0 @@
-import { createFileRoute } from '@tanstack/react-router'
-import { InstalledModsManager } from '@/pages/ModsPage'
-
-export const Route = createFileRoute('/mod-management')({
-  component: InstalledModsManager,
-})

--- a/frontend/src/routes/mod-subscriptions.tsx
+++ b/frontend/src/routes/mod-subscriptions.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { SubscribedModsManager } from '@/pages/ModsPage'
+
+export const Route = createFileRoute('/mod-subscriptions')({
+  component: SubscribedModsManager,
+})

--- a/frontend/src/types/collections.ts
+++ b/frontend/src/types/collections.ts
@@ -10,12 +10,6 @@ export interface Collection {
   isActive: boolean
 }
 
-export interface UpdatingMod {
-  readonly id: number
-  readonly name: string
-  readonly version?: string
-  readonly progress: number
-}
 
 export interface NewCollection {
   readonly name: string

--- a/frontend/src/types/mods.ts
+++ b/frontend/src/types/mods.ts
@@ -16,17 +16,10 @@ export interface ModSubscription {
   readonly imageAvailable: boolean
 }
 
-export interface UpdatingMod {
-  readonly id: number
-  readonly name: string
-  readonly version?: string
-  readonly progress: number
-}
 
 // Extended shape used by UI tables (optional fields for display/filtering)
 export interface ExtendedModSubscription extends ModSubscription {
   readonly author?: string
   readonly type?: 'mod' | 'mission' | 'map'
-  readonly hasUpdate?: boolean
   readonly sizeOnDisk?: string
 }


### PR DESCRIPTION
## Changes

- The backend leverages steam subscriptions so we don't need to have the concept of prompting the user to update their mods.
- Renamed the Installed route to be "Subscriptions" to be more in line with the steam functionality that is being used
- Removes all references to updating, or has update, or last updated in the UI as it creates confusion for the user who doesn't need to be concerned with this