### PR TITLE
Add ability to edit mods

### DIFF
--- a/frontend/src/components/ModsColumns.tsx
+++ b/frontend/src/components/ModsColumns.tsx
@@ -1,15 +1,17 @@
 import { type ColumnDef } from '@tanstack/react-table'
 import { Badge } from '@/components/ui/badge'
 import { Checkbox } from '@/components/ui/checkbox'
-import { IconUser, IconPuzzle, IconFlag, IconMap } from '@tabler/icons-react'
+import { IconUser, IconPuzzle, IconFlag, IconMap, IconCheck, IconX } from '@tabler/icons-react'
 
 import { DataTableColumnHeader } from '@/components/ModsDataTableHeader'
 import { DataTableRowActions } from '@/components/ModsDataRowActions'
+import { formatDateTime } from '@/lib/date'
 import type { ModSubscription } from '@/types/mods.ts'
 
 interface GetColumnsProps {
   onDelete: (id: number) => Promise<void>
   onDownload: (id: number) => Promise<void>
+  onEdit: (mod: ModSubscription) => void
   isLoading?: string | null
 }
 
@@ -29,6 +31,7 @@ const getTypeIcon = (type: ModSubscription['modType']) => {
 export const getColumns = ({
   onDelete,
   onDownload,
+  onEdit,
   isLoading,
 }: GetColumnsProps): ColumnDef<ModSubscription>[] => [
   {
@@ -106,12 +109,68 @@ export const getColumns = ({
     },
   },
   {
+    accessorKey: 'isServerMod',
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Server Mod" />,
+    cell: ({ row }) => {
+      const isServerMod = row.getValue('isServerMod') as boolean
+      return (
+        <div className="flex items-center gap-2">
+          {isServerMod ? (
+            <IconCheck className="h-4 w-4 text-green-500" />
+          ) : (
+            <IconX className="h-4 w-4 text-muted-foreground" />
+          )}
+        </div>
+      )
+    },
+    filterFn: (row, id, value) => {
+      return value.includes(row.getValue(id))
+    },
+  },
+  {
+    accessorKey: 'arguments',
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Arguments" />,
+    cell: ({ row }) => {
+      const args = row.getValue('arguments') as string | null
+      return (
+        <div className="max-w-[200px] truncate text-sm font-mono text-muted-foreground">
+          {args || '-'}
+        </div>
+      )
+    },
+  },
+  {
+    accessorKey: 'lastUpdated',
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Last Updated" />,
+    cell: ({ row }) => {
+      const lastUpdated = row.getValue('lastUpdated') as string | null
+      return (
+        <div className="text-sm text-muted-foreground">
+          {lastUpdated ? formatDateTime(lastUpdated) : 'Never'}
+        </div>
+      )
+    },
+  },
+  {
+    accessorKey: 'steamLastUpdated',
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Steam Updated" />,
+    cell: ({ row }) => {
+      const steamLastUpdated = row.getValue('steamLastUpdated') as string | null
+      return (
+        <div className="text-sm text-muted-foreground">
+          {steamLastUpdated ? formatDateTime(steamLastUpdated) : 'Unknown'}
+        </div>
+      )
+    },
+  },
+  {
     id: 'actions',
     cell: ({ row }) => (
       <DataTableRowActions
         row={row}
         onDelete={onDelete}
         onDownload={onDownload}
+        onEdit={onEdit}
         isLoading={isLoading}
       />
     ),

--- a/frontend/src/components/ModsDataRowActions.tsx
+++ b/frontend/src/components/ModsDataRowActions.tsx
@@ -1,11 +1,12 @@
 import { type Row } from '@tanstack/react-table'
-import { MoreHorizontal, Trash, Download } from 'lucide-react'
+import { MoreHorizontal, Trash, Download, Edit } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 
@@ -15,6 +16,7 @@ interface DataTableRowActionsProps {
   row: Row<ModSubscription>
   onDelete: (id: number) => Promise<void>
   onDownload: (id: number) => Promise<void>
+  onEdit: (mod: ModSubscription) => void
   isLoading?: string | null
 }
 
@@ -22,6 +24,7 @@ export function DataTableRowActions({
   row,
   onDelete,
   onDownload,
+  onEdit,
   isLoading,
 }: DataTableRowActionsProps) {
   const mod = row.original
@@ -35,6 +38,10 @@ export function DataTableRowActions({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-[160px]">
+        <DropdownMenuItem onClick={() => onEdit(mod)}>
+          <Edit className="mr-2 h-4 w-4" />
+          Edit
+        </DropdownMenuItem>
         <DropdownMenuItem
           onClick={() => onDownload(mod.steamId)}
           disabled={isLoading === 'downloading' || !!mod.localPath}
@@ -42,6 +49,7 @@ export function DataTableRowActions({
           <Download className="mr-2 h-4 w-4" />
           {mod.localPath ? 'Downloaded' : 'Download'}
         </DropdownMenuItem>
+        <DropdownMenuSeparator />
         <DropdownMenuItem
           onClick={() => onDelete(mod.steamId)}
           disabled={isLoading === 'removing'}

--- a/frontend/src/components/ModsEditDialog.tsx
+++ b/frontend/src/components/ModsEditDialog.tsx
@@ -1,0 +1,135 @@
+import { useState, useEffect } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Label } from '@/components/ui/label'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Textarea } from '@/components/ui/textarea'
+import type { ModSubscription } from '@/types/mods'
+
+interface ModsEditDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  mod: ModSubscription | null
+  onSave: (
+    steamId: number,
+    updates: { arguments: string | null; isServerMod: boolean }
+  ) => Promise<void>
+}
+
+export function ModsEditDialog({ open, onOpenChange, mod, onSave }: ModsEditDialogProps) {
+  const [arguments_, setArguments] = useState<string>('')
+  const [isServerMod, setIsServerMod] = useState<boolean>(false)
+  const [isSaving, setIsSaving] = useState(false)
+
+  // Reset form when mod changes or dialog opens
+  useEffect(() => {
+    if (mod && open) {
+      setArguments(mod.arguments || '')
+      setIsServerMod(mod.isServerMod)
+    }
+  }, [mod, open])
+
+  const handleSave = async () => {
+    if (!mod) return
+
+    setIsSaving(true)
+    try {
+      await onSave(mod.steamId, {
+        arguments: arguments_.trim() || null,
+        isServerMod,
+      })
+      onOpenChange(false)
+    } catch (error) {
+      console.error('Failed to save mod updates:', error)
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  if (!mod) return null
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[540px]">
+        <DialogHeader className="space-y-3">
+          <DialogTitle className="text-xl">Edit Mod Settings</DialogTitle>
+          <DialogDescription className="text-base">
+            Update the server configuration for <strong>{mod.name}</strong>
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6 py-2">
+          {/* Mod Info Section - Clean, minimal style */}
+          <div className="space-y-2 text-sm">
+            <div className="flex items-center gap-2">
+              <span className="text-muted-foreground w-20">Steam ID</span>
+              <span className="font-medium">{mod.steamId}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-muted-foreground w-20">Filename</span>
+              <span className="font-medium text-sm">{mod.filename}</span>
+            </div>
+          </div>
+
+          {/* Divider */}
+          <div className="border-t" />
+
+          {/* Server Mod Checkbox */}
+          <div className="flex items-start space-x-3">
+            <Checkbox
+              id="server-mod"
+              checked={isServerMod}
+              onCheckedChange={(checked) => setIsServerMod(checked as boolean)}
+              className="mt-0.5"
+            />
+            <div className="space-y-1 flex-1">
+              <Label
+                htmlFor="server-mod"
+                className="text-sm font-medium leading-none cursor-pointer"
+              >
+                Server-side only mod
+              </Label>
+              <p className="text-sm text-muted-foreground leading-snug">
+                Enable if this mod only needs to run on the server
+              </p>
+            </div>
+          </div>
+
+          {/* Arguments Textarea */}
+          <div className="space-y-3">
+            <Label htmlFor="arguments" className="text-sm font-medium">
+              Command line arguments
+            </Label>
+            <Textarea
+              id="arguments"
+              placeholder="e.g., -serverMod -filePatching"
+              value={arguments_}
+              onChange={(e) => setArguments(e.target.value)}
+              rows={4}
+              className="font-mono text-sm resize-none"
+            />
+            <p className="text-xs text-muted-foreground leading-relaxed">
+              Optional command line arguments to pass when loading this mod
+            </p>
+          </div>
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isSaving}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={isSaving}>
+            {isSaving ? 'Saving...' : 'Save'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/pages/ModsPage.tsx
+++ b/frontend/src/pages/ModsPage.tsx
@@ -6,7 +6,8 @@ import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { IconPlus } from '@tabler/icons-react'
 import { ModsSubscribeDialog } from '@/components/ModsSubscribeDialog'
-import type { ExtendedModSubscription } from '@/types/mods'
+import { ModsEditDialog } from '@/components/ModsEditDialog'
+import type { ExtendedModSubscription, ModSubscription } from '@/types/mods'
 import type { CreateCollectionRequest } from '@/types/api'
 
 export function SubscribedModsManager() {
@@ -15,6 +16,7 @@ export function SubscribedModsManager() {
     isLoading,
     addModSubscription,
     removeModSubscription,
+    updateModSubscription,
     downloadMod,
     isDownloading,
   } = useMods()
@@ -42,9 +44,26 @@ export function SubscribedModsManager() {
     // This will be implemented when the collections API is available
   }
 
+  // Edit dialog state and handlers
+  const [editOpen, setEditOpen] = useState(false)
+  const [editingMod, setEditingMod] = useState<ModSubscription | null>(null)
+
+  const handleEdit = (mod: ModSubscription) => {
+    setEditingMod(mod)
+    setEditOpen(true)
+  }
+
+  const handleEditSave = async (
+    steamId: number,
+    updates: { arguments: string | null; isServerMod: boolean }
+  ) => {
+    await updateModSubscription(steamId, updates)
+  }
+
   const columns = getColumns({
     onDelete: handleDelete,
     onDownload: handleDownload,
+    onEdit: handleEdit,
     isLoading: isDownloading ? 'downloading' : isLoading ? 'loading' : null,
   })
 
@@ -72,6 +91,13 @@ export function SubscribedModsManager() {
         open={subscribeOpen}
         onOpenChange={setSubscribeOpen}
         onSubscribe={handleSubscribeMods}
+      />
+
+      <ModsEditDialog
+        open={editOpen}
+        onOpenChange={setEditOpen}
+        mod={editingMod}
+        onSave={handleEditSave}
       />
     </div>
   )


### PR DESCRIPTION
- Introduced an edit option in the Mods data table with a new `onEdit` prop.
- Added a new `ModsEditDialog` component for editing mod details.
- Implemented new columns for displaying 'Server Mod', 'Arguments', 'Last Updated', and 'Steam Updated' in the Mods data table.
- Updated `DataTableRowActions` to include an edit action in the dropdown menu.
- Enhanced the `getColumns` function to support the new edit functionality and additional columns.