### PR TITLE
Fix mods not showing images

### DIFF
--- a/frontend/src/components/ModDetailSidebar.tsx
+++ b/frontend/src/components/ModDetailSidebar.tsx
@@ -12,6 +12,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import type { ModSubscription } from '@/types/mods'
+import { BACKEND_BASE_URL } from '@/services/api'
 
 interface ModDetailSidebarProps {
   mod: ModSubscription | null
@@ -186,9 +187,10 @@ export function ModDetailSidebar({
           {mod.imageAvailable && (
             <div className="w-full aspect-video rounded-md overflow-hidden bg-muted -mt-1">
               <img
-                src={`/api/arma3/mod/subscription/${mod.id}/image`}
+                src={`${BACKEND_BASE_URL}/api/arma3/mod/subscription/${mod.id}/image`}
                 alt={mod.name}
-                className="w-full h-full object-cover"
+                className="w-full h-full object-contain"
+                crossOrigin="anonymous"
               />
             </div>
           )}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -4,6 +4,11 @@ import { handleApiError } from '@/lib/error-handler'
 // API base configuration
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api'
 
+// Export backend base URL (without /api) for direct access to endpoints like images
+export const BACKEND_BASE_URL = import.meta.env.VITE_API_BASE_URL
+  ? import.meta.env.VITE_API_BASE_URL.replace(/\/api$/, '')
+  : 'http://localhost:5000'
+
 // Create axios instance with default configuration
 export const api = axios.create({
   baseURL: API_BASE_URL,


### PR DESCRIPTION
- Export BACKEND_BASE_URL instead of relying on VITE proxy for image url redirects