### PR TITLE
Use utility function for mod file size that allows better specificity

### DIFF
--- a/frontend/src/hooks/useCollections.ts
+++ b/frontend/src/hooks/useCollections.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { collections as collectionsService } from '@/services'
 import { handleApiError } from '@/lib/error-handler'
+import { formatFileSize } from '@/lib/filesize'
 import type { Collection, NewCollection } from '@/types/collections'
 import type { CollectionResponse } from '@/types/api'
 
@@ -22,9 +23,7 @@ const transformApiCollections = (collections: CollectionResponse[]): Collection[
         arguments: entry.mod!.arguments,
         isServerMod: entry.mod!.server_mod,
         sizeBytes: entry.mod!.size_bytes,
-        size: entry.mod!.size_bytes
-          ? `${Math.round(entry.mod!.size_bytes / 1024 / 1024)} MB`
-          : 'Unknown',
+        size: formatFileSize(entry.mod!.size_bytes),
         lastUpdated: entry.mod!.last_updated,
         steamLastUpdated: entry.mod!.steam_last_updated,
         shouldUpdate: entry.mod!.should_update,

--- a/frontend/src/hooks/useMods.test.ts
+++ b/frontend/src/hooks/useMods.test.ts
@@ -30,7 +30,7 @@ const mockModSubscriptions = [
     arguments: null,
     isServerMod: false,
     sizeBytes: 1024000,
-    size: '1 MB',
+    size: '1000.000 KB',
     lastUpdated: null,
     steamLastUpdated: '2024-01-01T00:00:00Z',
     shouldUpdate: true,

--- a/frontend/src/hooks/useMods.ts
+++ b/frontend/src/hooks/useMods.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { mods } from '@/services'
 import { handleApiError, showInfoToast } from '@/lib/error-handler'
+import { formatFileSize } from '@/lib/filesize'
 import type { ModHelper, ModSubscriptionResponse } from '@/types/api'
 import type { ModSubscription } from '@/types/mods'
 
@@ -17,7 +18,7 @@ const transformApiMods = (response: ModSubscriptionResponse[]): ModSubscription[
     arguments: mod.arguments,
     isServerMod: mod.server_mod,
     sizeBytes: mod.size_bytes,
-    size: mod.size_bytes ? `${Math.round(mod.size_bytes / 1024 / 1024)} MB` : 'Unknown',
+    size: formatFileSize(mod.size_bytes),
     lastUpdated: mod.last_updated,
     steamLastUpdated: mod.steam_last_updated,
     shouldUpdate: mod.should_update,

--- a/frontend/src/lib/filesize.ts
+++ b/frontend/src/lib/filesize.ts
@@ -1,0 +1,32 @@
+/**
+ * File size formatting utilities
+ */
+
+/**
+ * Formats a file size in bytes to a human-readable string with appropriate units
+ * @param bytes - File size in bytes
+ * @param decimals - Number of decimal places (defaults to 3 for KB, 2 for larger units)
+ * @returns Formatted file size string (e.g., "49.503 KB", "1.25 MB", "2.10 GB")
+ */
+export function formatFileSize(bytes: number | null | undefined): string {
+  if (bytes === null || bytes === undefined || bytes === 0) {
+    return 'Unknown'
+  }
+
+  const kilobytes = bytes / 1024
+  const megabytes = kilobytes / 1024
+  const gigabytes = megabytes / 1024
+
+  // Use KB for files < 1 MB with 3 decimal places for precision
+  if (megabytes < 1) {
+    return `${kilobytes.toFixed(3)} KB`
+  }
+
+  // Use MB for files < 1 GB with 2 decimal places
+  if (gigabytes < 1) {
+    return `${megabytes.toFixed(2)} MB`
+  }
+
+  // Use GB for larger files with 2 decimal places
+  return `${gigabytes.toFixed(2)} GB`
+}

--- a/frontend/src/pages/ModsPage.test.tsx
+++ b/frontend/src/pages/ModsPage.test.tsx
@@ -21,7 +21,7 @@ const mockMods = [
     arguments: null,
     isServerMod: false,
     sizeBytes: 1024000,
-    size: '1 MB',
+    size: '1000.000 KB',
     lastUpdated: null,
     steamLastUpdated: '2024-01-01T00:00:00Z',
     shouldUpdate: true,

--- a/frontend/src/types/mods.ts
+++ b/frontend/src/types/mods.ts
@@ -9,7 +9,7 @@ export interface ModSubscription {
   readonly arguments: string | null
   readonly isServerMod: boolean
   readonly sizeBytes: number | null
-  readonly size: string // Formatted size string (e.g. "150 MB")
+  readonly size: string // Formatted size string (e.g. "49.503 KB", "1.25 MB", "2.10 GB")
   readonly lastUpdated: string | null
   readonly steamLastUpdated: string | null
   readonly shouldUpdate: boolean


### PR DESCRIPTION
- Add formatFileSize()
- Replace different file size rendering approaches with one utility function
- Update tests and pages to use new utility