### PR TITLE
Implement load order adjustment for mods in reorder_mod_load and useCollections.ts

### DIFF
--- a/backend/app/utils/helpers.py
+++ b/backend/app/utils/helpers.py
@@ -351,6 +351,28 @@ class Arma3ModManager:
         ).first()
         if not mod:
             raise Exception("Mod not found")
+
+        old_load_order = mod.load_order
+        if old_load_order == load_order:
+            return
+
+        if old_load_order < load_order:
+            mods_to_shift = ModCollectionEntry.query.filter(
+                ModCollectionEntry.collection_id == collection_id,
+                ModCollectionEntry.load_order > old_load_order,
+                ModCollectionEntry.load_order <= load_order,
+            ).all()
+            for m in mods_to_shift:
+                m.load_order -= 1
+        else:
+            mods_to_shift = ModCollectionEntry.query.filter(
+                ModCollectionEntry.collection_id == collection_id,
+                ModCollectionEntry.load_order >= load_order,
+                ModCollectionEntry.load_order < old_load_order,
+            ).all()
+            for m in mods_to_shift:
+                m.load_order += 1
+
         mod.load_order = load_order
         db.session.commit()
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -521,6 +521,7 @@ class TestArma3API:
         )
         db.session.commit()
 
+        # confirm mods are in collection
         assert (
             len(
                 ModCollectionEntry.query.filter(
@@ -534,6 +535,8 @@ class TestArma3API:
             "/api/arma3/mod/collection/1/mods/1/load/3",
         )
         assert reply.status_code == HTTPStatus.OK
+
+        # confirm load order is as expected
         assert (
             ModCollectionEntry.query.filter(
                 ModCollectionEntry.collection_id == 1,
@@ -562,10 +565,13 @@ class TestArma3API:
             == 2
         )
 
+        # modify the load order for the first mod
         reply = client.patch(
             "/api/arma3/mod/collection/1/mods/1/load/1",
         )
         assert reply.status_code == HTTPStatus.OK
+
+        # confirm the load order changed
         assert (
             ModCollectionEntry.query.filter(
                 ModCollectionEntry.collection_id == 1,
@@ -594,10 +600,13 @@ class TestArma3API:
             == 3
         )
 
+        # test updating the load order for the second mod
         reply = client.patch(
             "/api/arma3/mod/collection/1/mods/2/load/3",
         )
         assert reply.status_code == HTTPStatus.OK
+
+        # confirm the load order updated for the second mod
         assert (
             ModCollectionEntry.query.filter(
                 ModCollectionEntry.collection_id == 1,

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -483,6 +483,22 @@ class TestArma3API:
         add_cba_to_db  # noqa: B018
         add_ace_to_db  # noqa: B018
         db.session.add(
+            Mod(
+                steam_id=843577117,
+                name="JSRS SOUNDMOD",
+                filename="@jsrs_soundmod",
+                local_path=None,
+                arguments=None,
+                server_mod=False,
+                size_bytes=0,
+                last_updated=datetime.now(),
+                steam_last_updated=datetime.now(),
+                should_update=True,
+            )
+        )
+        db.session.commit()
+
+        db.session.add(
             ModCollectionEntry(
                 collection_id=1,
                 mod_id=1,
@@ -496,16 +512,28 @@ class TestArma3API:
                 load_order=2,
             )
         )
-        # confirm mods are in collection
+        db.session.add(
+            ModCollectionEntry(
+                collection_id=1,
+                mod_id=3,
+                load_order=3,
+            )
+        )
+        db.session.commit()
+
         assert (
             len(
                 ModCollectionEntry.query.filter(
                     ModCollectionEntry.collection_id == 1,
                 ).all()
             )
-            == 2
+            == 3
         )
-        # confirm load order is as expected
+
+        reply = client.patch(
+            "/api/arma3/mod/collection/1/mods/1/load/3",
+        )
+        assert reply.status_code == HTTPStatus.OK
         assert (
             ModCollectionEntry.query.filter(
                 ModCollectionEntry.collection_id == 1,
@@ -513,29 +541,8 @@ class TestArma3API:
             )
             .first()
             .load_order
-            == 1
+            == 3
         )
-        # modify the load order for the first mod
-        reply = client.patch(
-            "/api/arma3/mod/collection/1/mods/1/load/2",
-        )
-        assert reply.status_code == HTTPStatus.OK
-        # confirm the load order changed
-        assert (
-            ModCollectionEntry.query.filter(
-                ModCollectionEntry.collection_id == 1,
-                ModCollectionEntry.mod_id == 1,
-            )
-            .first()
-            .load_order
-            == 2
-        )
-        # test updating the load order for the second mod
-        reply = client.patch(
-            "/api/arma3/mod/collection/1/mods/2/load/1",
-        )
-        assert reply.status_code == HTTPStatus.OK
-        # confirm the load order updated for the second mod
         assert (
             ModCollectionEntry.query.filter(
                 ModCollectionEntry.collection_id == 1,
@@ -544,6 +551,79 @@ class TestArma3API:
             .first()
             .load_order
             == 1
+        )
+        assert (
+            ModCollectionEntry.query.filter(
+                ModCollectionEntry.collection_id == 1,
+                ModCollectionEntry.mod_id == 3,
+            )
+            .first()
+            .load_order
+            == 2
+        )
+
+        reply = client.patch(
+            "/api/arma3/mod/collection/1/mods/1/load/1",
+        )
+        assert reply.status_code == HTTPStatus.OK
+        assert (
+            ModCollectionEntry.query.filter(
+                ModCollectionEntry.collection_id == 1,
+                ModCollectionEntry.mod_id == 1,
+            )
+            .first()
+            .load_order
+            == 1
+        )
+        assert (
+            ModCollectionEntry.query.filter(
+                ModCollectionEntry.collection_id == 1,
+                ModCollectionEntry.mod_id == 2,
+            )
+            .first()
+            .load_order
+            == 2
+        )
+        assert (
+            ModCollectionEntry.query.filter(
+                ModCollectionEntry.collection_id == 1,
+                ModCollectionEntry.mod_id == 3,
+            )
+            .first()
+            .load_order
+            == 3
+        )
+
+        reply = client.patch(
+            "/api/arma3/mod/collection/1/mods/2/load/3",
+        )
+        assert reply.status_code == HTTPStatus.OK
+        assert (
+            ModCollectionEntry.query.filter(
+                ModCollectionEntry.collection_id == 1,
+                ModCollectionEntry.mod_id == 1,
+            )
+            .first()
+            .load_order
+            == 1
+        )
+        assert (
+            ModCollectionEntry.query.filter(
+                ModCollectionEntry.collection_id == 1,
+                ModCollectionEntry.mod_id == 2,
+            )
+            .first()
+            .load_order
+            == 3
+        )
+        assert (
+            ModCollectionEntry.query.filter(
+                ModCollectionEntry.collection_id == 1,
+                ModCollectionEntry.mod_id == 3,
+            )
+            .first()
+            .load_order
+            == 2
         )
 
     def test_notification_create(self, client: FlaskClient) -> None:

--- a/frontend/src/hooks/useCollections.ts
+++ b/frontend/src/hooks/useCollections.ts
@@ -141,6 +141,7 @@ export function useCollections() {
     },
     onError: (error) => {
       handleApiError(error, 'Failed to reorder mod in collection')
+      queryClient.invalidateQueries({ queryKey: ['collections'] })
     },
   })
 
@@ -230,6 +231,7 @@ export function useCollections() {
       })
     } catch (error) {
       console.error('Reorder mod failed:', error)
+      throw error
     }
   }
 


### PR DESCRIPTION
## Bugs

For [task](https://www.notion.so/Mod-load-order-is-bugged-AF-28601d158dca8019b912e7fa841405c1?source=copy_link)

### Backend

The `reorder_mod_load` function in `backend/app/utils/helpers.py` sets one mod's `load_order` to a new value without adjusting other mods. This creates duplicate `load_order` values, causing undefined ordering.

```347:355:backend/app/utils/helpers.py
@staticmethod
def reorder_mod_load(collection_id: int, mod_id: int, load_order: int) -> None:
    mod = ModCollectionEntry.query.filter(
        ModCollectionEntry.collection_id == collection_id,
        ModCollectionEntry.mod_id == mod_id,
    ).first()
    if not mod:
        raise Exception("Mod not found")
    mod.load_order = load_order
    db.session.commit()
```

When the user drags mod A from position 1 to position 3, it just sets `mod_A.load_order = 3`. If mod B was already at position 3, now both have `load_order = 3`, resulting in undefined ordering.

### Frontend

1. Each drag operation triggers an immediate API call (in CollectionsModsList.tsx)
2. The mutation's `onSuccess` handler invalidates the query, triggering a refetch (in useCollections.ts)
3. Rapid dragging creates race conditions where local state keeps resetting
