### PR TITLE
feat(frontend): add Creator DLC selection UI

### DIFF
--- a/frontend/src/components/ServerSettings.tsx
+++ b/frontend/src/components/ServerSettings.tsx
@@ -6,8 +6,10 @@ import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
 
 import type { ServerConfiguration } from '@/types/settings'
+import { type CreatorDLCCode, CREATOR_DLC_INFO } from '@/types/server'
 
 interface ServerSettingsProps {
   settings: ServerConfiguration
@@ -28,6 +30,16 @@ export function ServerSettings({ settings, onUpdate, showCard = true }: ServerSe
         [field]: value,
       })
     }
+
+  const handleCDLCToggle = (dlcCode: CreatorDLCCode, enabled: boolean) => {
+    onUpdate({
+      ...settings,
+      load_creator_dlc: {
+        ...settings.load_creator_dlc,
+        [dlcCode]: enabled,
+      },
+    })
+  }
 
   const content = (
     <div className="space-y-6">
@@ -189,6 +201,38 @@ export function ServerSettings({ settings, onUpdate, showCard = true }: ServerSe
               onChange={handleInputChange('basic_config_file')}
             />
           </div>
+        </div>
+      </div>
+
+      {/* Creator DLC */}
+      <div className="space-y-4">
+        <h4 className="text-sm font-medium text-muted-foreground">Creator DLC</h4>
+        <p className="text-xs text-muted-foreground">
+          Select which Creator DLC content to load with the server. Players must own the DLC to
+          join.
+        </p>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {(Object.keys(CREATOR_DLC_INFO) as CreatorDLCCode[]).map((dlcCode) => {
+            const dlcInfo = CREATOR_DLC_INFO[dlcCode]
+            return (
+              <div
+                key={dlcCode}
+                className="flex items-center justify-between rounded-lg border p-3"
+              >
+                <div className="space-y-0.5">
+                  <Label htmlFor={`cdlc-${dlcCode}`} className="text-sm font-medium cursor-pointer">
+                    {dlcInfo.name}
+                  </Label>
+                  <p className="text-xs text-muted-foreground">{dlcInfo.description}</p>
+                </div>
+                <Switch
+                  id={`cdlc-${dlcCode}`}
+                  checked={settings.load_creator_dlc[dlcCode]}
+                  onCheckedChange={(checked) => handleCDLCToggle(dlcCode, checked)}
+                />
+              </div>
+            )
+          })}
         </div>
       </div>
 

--- a/frontend/src/pages/ControlPanelPage.tsx
+++ b/frontend/src/pages/ControlPanelPage.tsx
@@ -9,6 +9,7 @@ import { serverService } from '@/services/server.service'
 import { handleApiError } from '@/lib/error-handler'
 import type { Collection } from '@/types/collections'
 import type { ServerConfig, CreateServerRequest, Schedule } from '@/types/server'
+import { DEFAULT_CREATOR_DLC_SETTINGS } from '@/types/server'
 import type { ServerActionRequest } from '@/types/api'
 import type { ServerConfiguration } from '@/types/settings'
 
@@ -44,6 +45,7 @@ export function ControlPanelPage() {
     client_mods: '',
     additional_params: '',
     server_binary: '',
+    load_creator_dlc: { ...DEFAULT_CREATOR_DLC_SETTINGS },
   })
 
   // Schedules state
@@ -88,6 +90,7 @@ export function ControlPanelPage() {
         client_mods: server.client_mods || '',
         additional_params: server.additional_params || '',
         server_binary: server.server_binary || '',
+        load_creator_dlc: server.load_creator_dlc || { ...DEFAULT_CREATOR_DLC_SETTINGS },
       })
       hasInitializedSettings.current = true
     }
@@ -149,6 +152,7 @@ export function ControlPanelPage() {
         client_mods: serverSettings.client_mods || null,
         additional_params: serverSettings.additional_params || null,
         server_binary: serverSettings.server_binary,
+        load_creator_dlc: serverSettings.load_creator_dlc,
       }
 
       await serverService.updateServer(server.id, serverData)

--- a/frontend/src/types/server.ts
+++ b/frontend/src/types/server.ts
@@ -1,6 +1,45 @@
 // ----- Backend-aligned server config types (arma3/server endpoints) -----
 import type { CollectionResponse } from '@/types/api'
 
+/**
+ * Creator DLC codes used by the backend.
+ * Note: Some codes differ from Arma 3's official codes:
+ * - pf (backend) = vn (Arma 3) - S.O.G. Prairie Fire
+ * - ic (backend) = csla (Arma 3) - CSLA Iron Curtain
+ * - sh (backend) = spe (Arma 3) - Spearhead 1944
+ */
+export type CreatorDLCCode = 'pf' | 'gm' | 'ic' | 'ws' | 'sh' | 'rf' | 'ef'
+
+export interface CreatorDLCSettings {
+  pf: boolean // S.O.G. Prairie Fire
+  gm: boolean // Global Mobilization
+  ic: boolean // CSLA Iron Curtain
+  ws: boolean // Western Sahara
+  sh: boolean // Spearhead 1944
+  rf: boolean // Reaction Forces
+  ef: boolean // Expeditionary Forces
+}
+
+export const CREATOR_DLC_INFO: Record<CreatorDLCCode, { name: string; description: string }> = {
+  pf: { name: 'S.O.G. Prairie Fire', description: 'Vietnam War expansion' },
+  gm: { name: 'Global Mobilization', description: 'Cold War Germany expansion' },
+  ic: { name: 'CSLA Iron Curtain', description: 'Czechoslovak Army expansion' },
+  ws: { name: 'Western Sahara', description: 'North African conflict expansion' },
+  sh: { name: 'Spearhead 1944', description: 'World War II expansion' },
+  rf: { name: 'Reaction Forces', description: 'Modern military expansion' },
+  ef: { name: 'Expeditionary Forces', description: 'Expeditionary warfare expansion' },
+}
+
+export const DEFAULT_CREATOR_DLC_SETTINGS: CreatorDLCSettings = {
+  pf: false,
+  gm: false,
+  ic: false,
+  ws: false,
+  sh: false,
+  rf: false,
+  ef: false,
+}
+
 export interface ServerResources {
   cpu_usage_percent: number
   ram_usage_percent: number
@@ -32,6 +71,7 @@ export interface ServerConfig {
   resources: ServerResources
   created_at: string
   updated_at: string
+  load_creator_dlc: CreatorDLCSettings
   // Sensitive (optional, only returned when include_sensitive=true)
   password?: string | null
   admin_password?: string | null
@@ -51,6 +91,7 @@ export interface CreateServerRequest {
   client_mods?: string | null
   additional_params?: string | null
   server_binary: string
+  load_creator_dlc?: Partial<CreatorDLCSettings>
 }
 
 export type UpdateServerRequest = Partial<CreateServerRequest>

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -8,6 +8,8 @@ export interface NotificationSettings {
   }
 }
 
+import type { CreatorDLCSettings } from '@/types/server'
+
 export interface ServerConfiguration {
   name: string
   description: string
@@ -22,6 +24,7 @@ export interface ServerConfiguration {
   client_mods: string
   additional_params: string
   server_binary: string
+  load_creator_dlc: CreatorDLCSettings
 }
 
 export interface SecuritySettings {


### PR DESCRIPTION
Add ability to select which Creator DLC content to load with the server.
Changes include:
- Add CreatorDLCSettings type and CREATOR_DLC_INFO metadata
- Add load_creator_dlc to ServerConfig and ServerConfiguration interfaces
- Add CDLC toggle switches to ServerSettings component
- Handle CDLC state loading and saving in ControlPanelPage

https://claude.ai/code/session_01HyNLpWnGY8kHaitku68Qe4