### PR TITLE
fix(frontend): suppress error toast for expected collection check failure

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,12 @@
-import axios from 'axios'
+import axios, { type InternalAxiosRequestConfig } from 'axios'
 import { handleApiError } from '@/lib/error-handler'
+
+// Extend Axios config to support custom options
+declare module 'axios' {
+  interface AxiosRequestConfig {
+    skipErrorToast?: boolean
+  }
+}
 
 // API base configuration
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api'
@@ -44,8 +51,11 @@ api.interceptors.response.use(
       return Promise.reject(error)
     }
 
-    // Show error toast for other errors
-    handleApiError(error)
+    // Show error toast unless explicitly suppressed
+    const config = error.config as InternalAxiosRequestConfig | undefined
+    if (!config?.skipErrorToast) {
+      handleApiError(error)
+    }
 
     return Promise.reject(error)
   }

--- a/frontend/src/services/mods.service.ts
+++ b/frontend/src/services/mods.service.ts
@@ -99,6 +99,8 @@ export const modService = {
   },
 
   // Get mods from Steam collection
+  // Note: skipErrorToast is used because this is often called speculatively
+  // to check if an ID is a collection - a 400 "Not a collection" error is expected
   getSteamCollectionMods: async (
     collectionId: number,
     excludeSubscribed = false
@@ -106,7 +108,7 @@ export const modService = {
     const params = excludeSubscribed ? { exclude_subscribed: 'true' } : {}
     const response = await api.get<SteamCollectionResponse>(
       `/arma3/steam/collection/${collectionId}`,
-      { params }
+      { params, skipErrorToast: true }
     )
     return response.data.results
   },


### PR DESCRIPTION
When subscribing to a mod, the frontend speculatively checks if the ID
is a Steam collection to auto-expand it. A 400 "Not a collection" error
is expected when the ID is a regular mod, not a Steam collection. This
change adds a skipErrorToast option to the Axios interceptor and uses it
for the collection check, preventing the confusing error dialog.

https://claude.ai/code/session_01DxfbqSGdaDSwuJ7nTZi78P