### PR TITLE
fix(frontend): make download now checkbox trigger downloads on subscription

### DIFF
--- a/frontend/src/components/AddModsDialog.tsx
+++ b/frontend/src/components/AddModsDialog.tsx
@@ -31,7 +31,7 @@ export function AddModsDialog({
   existingModIds,
   collectionName,
 }: AddModsDialogProps) {
-  const { modSubscriptions, addModSubscription, downloadMod } = useMods()
+  const { modSubscriptions, addModSubscription, downloadModById } = useMods()
   const [selectedModIds, setSelectedModIds] = useState<number[]>([])
   const [searchQuery, setSearchQuery] = useState('')
   const [isSubscribeDialogOpen, setIsSubscribeDialogOpen] = useState(false)
@@ -102,9 +102,9 @@ export function AddModsDialog({
     steamIds.forEach((id) => pendingSteamIds.current.add(id))
 
     for (const steamId of steamIds) {
-      await addModSubscription(steamId)
-      if (downloadNow) {
-        downloadMod(steamId)
+      const modId = await addModSubscription(steamId)
+      if (downloadNow && modId !== undefined) {
+        downloadModById(modId)
       }
     }
   }

--- a/frontend/src/hooks/useMods.ts
+++ b/frontend/src/hooks/useMods.ts
@@ -56,7 +56,9 @@ export function useMods() {
   // Mutations
   const addModSubscriptionMutation = useMutation({
     mutationFn: async (steamId: number) => {
-      await mods.addModSubscriptions([{ steam_id: steamId }])
+      const response = await mods.addModSubscriptions([{ steam_id: steamId }])
+      // Return the first created mod ID (we only add one at a time)
+      return response.ids[0]
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['mods'] })
@@ -172,11 +174,12 @@ export function useMods() {
   })
 
   // Action functions
-  const addModSubscription = async (steamId: number): Promise<void> => {
+  const addModSubscription = async (steamId: number): Promise<number | undefined> => {
     try {
-      await addModSubscriptionMutation.mutateAsync(steamId)
+      return await addModSubscriptionMutation.mutateAsync(steamId)
     } catch (error) {
       console.error('Add mod subscription failed:', error)
+      return undefined
     }
   }
 
@@ -211,6 +214,14 @@ export function useMods() {
 
     try {
       await downloadModMutation.mutateAsync(mod.id)
+    } catch (error) {
+      console.error('Download mod failed:', error)
+    }
+  }
+
+  const downloadModById = async (modId: number): Promise<void> => {
+    try {
+      await downloadModMutation.mutateAsync(modId)
     } catch (error) {
       console.error('Download mod failed:', error)
     }
@@ -255,6 +266,7 @@ export function useMods() {
     removeModSubscription,
     updateModSubscription,
     downloadMod,
+    downloadModById,
     uninstallMod,
     getModHelper,
 

--- a/frontend/src/pages/ModsPage.tsx
+++ b/frontend/src/pages/ModsPage.tsx
@@ -172,6 +172,7 @@ function SubscriptionsTabContent({
     removeModSubscription,
     updateModSubscription,
     downloadMod,
+    downloadModById,
     uninstallMod,
     downloadingModId,
     uninstallingModId,
@@ -271,13 +272,18 @@ function SubscriptionsTabContent({
   // Subscribe dialog state and handler
   const [subscribeOpen, setSubscribeOpen] = useState(false)
   const handleSubscribeMods = async (steamIds: number[], downloadNow: boolean) => {
-    for (const id of steamIds) {
-      await addModSubscription(id)
+    const createdModIds: number[] = []
+
+    for (const steamId of steamIds) {
+      const modId = await addModSubscription(steamId)
+      if (modId !== undefined) {
+        createdModIds.push(modId)
+      }
     }
 
     if (downloadNow) {
-      for (const id of steamIds) {
-        await downloadMod(id)
+      for (const modId of createdModIds) {
+        await downloadModById(modId)
       }
     }
   }


### PR DESCRIPTION
The "Download now" checkbox in the subscription dialog was not triggering
downloads because the download function attempted to look up newly-added
mods by steamId in the current (stale) mod subscriptions array. The React
Query cache invalidation is asynchronous, so the new mod wasn't available
yet when downloadMod was called.

Fixed by:
- Making addModSubscription return the created mod's database ID from the
  API response
- Adding downloadModById function that downloads by database ID directly
- Using the returned mod IDs to trigger downloads immediately after
  subscription

https://claude.ai/code/session_01UJgHo47sE4oqaGhhnh6fNS