### PR TITLE
feat(frontend): add checkbox selection and batch delete for collections

### DIFF
--- a/frontend/src/components/CollectionsColumns.tsx
+++ b/frontend/src/components/CollectionsColumns.tsx
@@ -1,9 +1,31 @@
 import { type ColumnDef } from '@tanstack/react-table'
 
+import { Checkbox } from '@/components/ui/checkbox'
 import { DataTableColumnHeader } from '@/components/ModsDataTableHeader'
 import type { Collection } from '@/types/collections'
 
 export const getColumns = (activeCollectionId?: number | null): ColumnDef<Collection>[] => [
+  {
+    id: 'select',
+    header: ({ table }) => (
+      <Checkbox
+        checked={
+          table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && 'indeterminate')
+        }
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Select row"
+      />
+    ),
+    enableSorting: false,
+    enableHiding: false,
+  },
   {
     accessorKey: 'name',
     header: ({ column }) => <DataTableColumnHeader column={column} title="Collection" />,

--- a/frontend/src/pages/CollectionDetailPage.tsx
+++ b/frontend/src/pages/CollectionDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useParams, useNavigate, useSearch } from '@tanstack/react-router'
-import { IconCheck, IconX, IconFilter, IconTrash } from '@tabler/icons-react'
+import { IconCheck, IconX, IconFilter } from '@tabler/icons-react'
 import { toast } from 'sonner'
 
 import { Button } from '@/components/ui/button'
@@ -13,7 +13,6 @@ import { useCollections } from '@/hooks/useCollections'
 import { useMods } from '@/hooks/useMods'
 import { useTitleEditing } from '@/hooks/useTitleEditing'
 import { RemoveModDialog } from '@/components/CollectionsRemoveModDialog'
-import { ConfirmationDialog } from '@/components/ConfirmationDialog'
 import { AddModsDialog } from '@/components/AddModsDialog'
 import { ModsList } from '@/components/CollectionsModsList'
 import { ModDetailSidebar } from '@/components/ModDetailSidebar'
@@ -32,7 +31,6 @@ export function CollectionDetailPage() {
     addModsToCollection,
     reorderModInCollection,
     updateCollectionName,
-    deleteCollection,
   } = useCollections()
 
   const { updateModSubscription, uninstallMod, downloadMod, downloadingModId, uninstallingModId } =
@@ -40,7 +38,6 @@ export function CollectionDetailPage() {
 
   const [isRemoveDialogOpen, setIsRemoveDialogOpen] = useState(false)
   const [isAddModsDialogOpen, setIsAddModsDialogOpen] = useState(false)
-  const [isDeleteCollectionDialogOpen, setIsDeleteCollectionDialogOpen] = useState(false)
   const [modToRemove, setModToRemove] = useState<ModToRemove | null>(null)
   const [selectedModId, setSelectedModId] = useState<number | null>(null)
   const [isSidebarOpen, setIsSidebarOpen] = useState(false)
@@ -142,13 +139,6 @@ export function CollectionDetailPage() {
     }
   }
 
-  const handleDeleteCollection = async () => {
-    if (!collection) return
-    await deleteCollection(collection.id)
-    toast.success('Collection deleted successfully')
-    navigate({ to: '/arma3/mods' })
-  }
-
   if (!collection) {
     return (
       <div className="space-y-4">
@@ -239,13 +229,6 @@ export function CollectionDetailPage() {
               <IconFilter className="h-4 w-4" />
             </Button>
             <DataTableButton onClick={() => handleAddMods(collection.id)}>Add</DataTableButton>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => setIsDeleteCollectionDialogOpen(true)}
-            >
-              <IconTrash className="h-4 w-4" />
-            </Button>
           </div>
         </div>
 
@@ -305,17 +288,6 @@ export function CollectionDetailPage() {
         onAddMods={handleAddModsToCollection}
         existingModIds={collection.mods.map((mod) => mod.id)}
         collectionName={collection.name}
-      />
-
-      <ConfirmationDialog
-        open={isDeleteCollectionDialogOpen}
-        onOpenChange={setIsDeleteCollectionDialogOpen}
-        title="Delete Collection"
-        description={`Are you sure you want to delete "${collection.name}"? This will permanently remove the collection and all mod associations. This action cannot be undone.`}
-        confirmText="Delete"
-        cancelText="Cancel"
-        variant="destructive"
-        onConfirm={handleDeleteCollection}
       />
     </div>
   )

--- a/frontend/src/pages/CollectionDetailPage.tsx
+++ b/frontend/src/pages/CollectionDetailPage.tsx
@@ -242,7 +242,6 @@ export function CollectionDetailPage() {
             <Button
               variant="ghost"
               size="icon"
-              className="text-muted-foreground hover:text-destructive"
               onClick={() => setIsDeleteCollectionDialogOpen(true)}
             >
               <IconTrash className="h-4 w-4" />

--- a/frontend/src/pages/CollectionDetailPage.tsx
+++ b/frontend/src/pages/CollectionDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useParams, useNavigate, useSearch } from '@tanstack/react-router'
-import { IconCheck, IconX, IconFilter } from '@tabler/icons-react'
+import { IconCheck, IconX, IconFilter, IconTrash } from '@tabler/icons-react'
 import { toast } from 'sonner'
 
 import { Button } from '@/components/ui/button'
@@ -13,6 +13,7 @@ import { useCollections } from '@/hooks/useCollections'
 import { useMods } from '@/hooks/useMods'
 import { useTitleEditing } from '@/hooks/useTitleEditing'
 import { RemoveModDialog } from '@/components/CollectionsRemoveModDialog'
+import { ConfirmationDialog } from '@/components/ConfirmationDialog'
 import { AddModsDialog } from '@/components/AddModsDialog'
 import { ModsList } from '@/components/CollectionsModsList'
 import { ModDetailSidebar } from '@/components/ModDetailSidebar'
@@ -31,6 +32,7 @@ export function CollectionDetailPage() {
     addModsToCollection,
     reorderModInCollection,
     updateCollectionName,
+    deleteCollection,
   } = useCollections()
 
   const { updateModSubscription, uninstallMod, downloadMod, downloadingModId, uninstallingModId } =
@@ -38,6 +40,7 @@ export function CollectionDetailPage() {
 
   const [isRemoveDialogOpen, setIsRemoveDialogOpen] = useState(false)
   const [isAddModsDialogOpen, setIsAddModsDialogOpen] = useState(false)
+  const [isDeleteCollectionDialogOpen, setIsDeleteCollectionDialogOpen] = useState(false)
   const [modToRemove, setModToRemove] = useState<ModToRemove | null>(null)
   const [selectedModId, setSelectedModId] = useState<number | null>(null)
   const [isSidebarOpen, setIsSidebarOpen] = useState(false)
@@ -139,6 +142,13 @@ export function CollectionDetailPage() {
     }
   }
 
+  const handleDeleteCollection = async () => {
+    if (!collection) return
+    await deleteCollection(collection.id)
+    toast.success('Collection deleted successfully')
+    navigate({ to: '/arma3/mods' })
+  }
+
   if (!collection) {
     return (
       <div className="space-y-4">
@@ -229,6 +239,14 @@ export function CollectionDetailPage() {
               <IconFilter className="h-4 w-4" />
             </Button>
             <DataTableButton onClick={() => handleAddMods(collection.id)}>Add</DataTableButton>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="text-muted-foreground hover:text-destructive"
+              onClick={() => setIsDeleteCollectionDialogOpen(true)}
+            >
+              <IconTrash className="h-4 w-4" />
+            </Button>
           </div>
         </div>
 
@@ -288,6 +306,17 @@ export function CollectionDetailPage() {
         onAddMods={handleAddModsToCollection}
         existingModIds={collection.mods.map((mod) => mod.id)}
         collectionName={collection.name}
+      />
+
+      <ConfirmationDialog
+        open={isDeleteCollectionDialogOpen}
+        onOpenChange={setIsDeleteCollectionDialogOpen}
+        title="Delete Collection"
+        description={`Are you sure you want to delete "${collection.name}"? This will permanently remove the collection and all mod associations. This action cannot be undone.`}
+        confirmText="Delete"
+        cancelText="Cancel"
+        variant="destructive"
+        onConfirm={handleDeleteCollection}
       />
     </div>
   )


### PR DESCRIPTION
## Summary
- Add checkbox selection to the collections list table, matching the pattern used in subscriptions
- Add batch delete functionality that appears when collections are selected
- Remove the standalone delete button from the collection detail page header

## Test plan
- [ ] Select one or more collections using checkboxes
- [ ] Verify "Delete (N)" button appears when collections are selected
- [ ] Click delete and confirm the action deletes selected collections
- [ ] Verify the collection detail page no longer has a delete button

🤖 Generated with [Claude Code](https://claude.ai/claude-code)