### PR TITLE
fix(frontend): persist active mod collection selection

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+# Test output
+test-results
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,6 +54,12 @@
   "engines": {
     "node": ">=22.0.0"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@tailwindcss/oxide",
+      "esbuild"
+    ]
+  },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
     "@tanstack/react-query-devtools": "^5.84.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,12 +54,6 @@
   "engines": {
     "node": ">=22.0.0"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@tailwindcss/oxide",
-      "esbuild"
-    ]
-  },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
     "@tanstack/react-query-devtools": "^5.84.1",

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  '@tailwindcss/oxide': true
+  esbuild: true

--- a/frontend/src/components/CompactServerStatus.tsx
+++ b/frontend/src/components/CompactServerStatus.tsx
@@ -164,7 +164,7 @@ export function CompactServerStatus({
           <div className="space-y-1">
             <div className="text-sm font-semibold">Mod Collection</div>
             <div className="text-xs text-muted-foreground">
-              Collection selection not yet integrated with server actions
+              The selected collection is saved and loaded when the server starts
             </div>
           </div>
           <CollectionSelector

--- a/frontend/src/components/ServerCollectionSelector.tsx
+++ b/frontend/src/components/ServerCollectionSelector.tsx
@@ -95,14 +95,7 @@ export function CollectionSelector({
                     .map((collection) => (
                       <SelectItem key={collection.id} value={collection.id.toString()}>
                         <div className="flex flex-col items-start">
-                          <span className="font-medium">
-                            {collection.name}
-                            {collection.isActive && (
-                              <span className="ml-2 text-xs bg-blue-100 px-1.5 py-0.5 rounded">
-                                Available
-                              </span>
-                            )}
-                          </span>
+                          <span className="font-medium">{collection.name}</span>
                         </div>
                       </SelectItem>
                     ))}
@@ -135,14 +128,7 @@ export function CollectionSelector({
                 {collections.map((collection) => (
                   <SelectItem key={collection.id} value={collection.id.toString()}>
                     <div className="flex flex-col items-start">
-                      <span className="font-medium">
-                        {collection.name}
-                        {collection.isActive && (
-                          <span className="ml-2 text-xs bg-green-100 text-green-800 px-1.5 py-0.5 rounded">
-                            Active
-                          </span>
-                        )}
-                      </span>
+                      <span className="font-medium">{collection.name}</span>
                     </div>
                   </SelectItem>
                 ))}

--- a/frontend/src/hooks/useCollections.ts
+++ b/frontend/src/hooks/useCollections.ts
@@ -29,7 +29,6 @@ const transformApiCollections = (collections: CollectionResponse[]): Collection[
         imageAvailable: entry.mod!.image_available || false,
       })),
     createdAt: collection.created_at,
-    isActive: false, // TODO: Add isActive support when API provides it
   }))
 }
 
@@ -188,16 +187,6 @@ export function useCollections() {
     }
   }
 
-  const setActive = async (collectionId: number) => {
-    try {
-      // For now, this is just a local state update since API doesn't support it yet
-      // When API supports it, we'll make an API call here
-      console.log(`Setting collection ${collectionId} as active`)
-    } catch (error) {
-      console.error('Set active failed:', error)
-    }
-  }
-
   const updateCollectionName = async (collectionId: number, newName: string) => {
     const trimmedName = newName.trim()
     if (!trimmedName) return
@@ -259,7 +248,6 @@ export function useCollections() {
     toggleMod,
     removeModFromCollection,
     addModsToCollection,
-    setActive,
     updateCollectionName,
     updateCollection,
     reorderModInCollection,

--- a/frontend/src/pages/CollectionDetailPage.tsx
+++ b/frontend/src/pages/CollectionDetailPage.tsx
@@ -11,6 +11,9 @@ import { DataTableButton } from '@/components/DataTableButton'
 
 import { useCollections } from '@/hooks/useCollections'
 import { useMods } from '@/hooks/useMods'
+import { useServer } from '@/hooks/useServer'
+import { serverService } from '@/services/server.service'
+import { handleApiError } from '@/lib/error-handler'
 import { useTitleEditing } from '@/hooks/useTitleEditing'
 import { RemoveModDialog } from '@/components/CollectionsRemoveModDialog'
 import { AddModsDialog } from '@/components/AddModsDialog'
@@ -35,6 +38,10 @@ export function CollectionDetailPage() {
 
   const { updateModSubscription, uninstallMod, downloadMod, downloadingModId, uninstallingModId } =
     useMods()
+
+  const { servers, refetchServers } = useServer()
+  const server = servers[0]
+  const isActiveCollection = !!server && server.collection_id === collectionIdNum
 
   const [isRemoveDialogOpen, setIsRemoveDialogOpen] = useState(false)
   const [isAddModsDialogOpen, setIsAddModsDialogOpen] = useState(false)
@@ -122,6 +129,21 @@ export function CollectionDetailPage() {
       params: { collectionId },
       search: value ? { search: value } : {},
     })
+  }
+
+  const handleSetActiveCollection = async () => {
+    if (!server) {
+      toast.error('No server configuration found to assign the collection to')
+      return
+    }
+    try {
+      // The active collection is the one assigned to the server config.
+      await serverService.updateServerCollectionId(server.id, collectionIdNum)
+      toast.success(`Set "${collection?.name}" as the active collection`)
+      refetchServers()
+    } catch (error) {
+      handleApiError(error, 'Failed to set active collection')
+    }
   }
 
   const handleSaveCollectionName = async (newName: string) => {
@@ -221,6 +243,16 @@ export function CollectionDetailPage() {
             </p>
           </div>
           <div className="flex items-center gap-2">
+            {isActiveCollection ? (
+              <span className="inline-flex items-center gap-1.5 text-sm text-green-600">
+                <IconCheck className="h-4 w-4" />
+                Active
+              </span>
+            ) : (
+              <Button variant="outline" size="sm" onClick={handleSetActiveCollection}>
+                Set as Active
+              </Button>
+            )}
             <Button
               variant="ghost"
               size="icon"

--- a/frontend/src/pages/ControlPanelPage.test.tsx
+++ b/frontend/src/pages/ControlPanelPage.test.tsx
@@ -32,7 +32,6 @@ const mockCollection: Collection = {
   description: 'A test collection',
   createdAt: '2024-01-01T00:00:00Z',
   mods: [],
-  isActive: true,
 }
 
 const mockServer: ServerConfig = {
@@ -88,7 +87,6 @@ describe('ControlPanelPage Start Button', () => {
       toggleMod: vi.fn(),
       removeModFromCollection: vi.fn(),
       addModsToCollection: vi.fn(),
-      setActive: vi.fn(),
       updateCollectionName: vi.fn(),
     })
 

--- a/frontend/src/pages/ControlPanelPage.tsx
+++ b/frontend/src/pages/ControlPanelPage.tsx
@@ -64,12 +64,22 @@ export function ControlPanelPage() {
     refetchServers()
   }, [refetchServers])
 
-  // Set the selected collection when collections are loaded
+  // Seed the selected startup collection from the value persisted on the server
+  // config so the dropdown reflects the saved collection after a refresh, rather
+  // than always reverting to the first collection in the list. Fall back to the
+  // first collection only when nothing has been persisted yet.
   useEffect(() => {
-    if (collections.length > 0 && !selectedStartupCollection) {
+    const activeServer = servers[0]
+    const persisted =
+      activeServer?.collection_id != null
+        ? collections.find((c) => c.id === activeServer.collection_id)
+        : undefined
+    if (persisted) {
+      setSelectedStartupCollection(persisted)
+    } else if (collections.length > 0 && !selectedStartupCollection) {
       setSelectedStartupCollection(collections[0])
     }
-  }, [collections, selectedStartupCollection])
+  }, [servers, collections, selectedStartupCollection])
 
   // Load server settings only once when servers are first available
   // This prevents form state from being overwritten during refetches
@@ -120,8 +130,23 @@ export function ControlPanelPage() {
     }
   }
 
-  const handleStartupCollectionChange = (collection: Collection | null) => {
+  const handleStartupCollectionChange = async (collection: Collection | null) => {
     setSelectedStartupCollection(collection)
+
+    const activeServer = servers[0]
+    if (!activeServer) return
+
+    try {
+      // Persist the selection so it is used the next time the server starts and
+      // survives a page refresh.
+      await serverService.updateServerCollectionId(activeServer.id, collection?.id ?? null)
+      toast.success(
+        collection ? `Startup collection set to "${collection.name}"` : 'Startup collection cleared'
+      )
+      refetchServers()
+    } catch (error) {
+      handleApiError(error, 'Failed to update startup collection')
+    }
   }
 
   const handleServerSettingsUpdate = (settings: ServerConfiguration) => {

--- a/frontend/src/pages/ModsPage.test.tsx
+++ b/frontend/src/pages/ModsPage.test.tsx
@@ -107,7 +107,6 @@ const mockUseCollections = {
   toggleMod: vi.fn(),
   removeModFromCollection: vi.fn(),
   addModsToCollection: vi.fn(),
-  setActive: vi.fn(),
   updateCollectionName: vi.fn(),
   updateCollection: vi.fn(),
   reorderModInCollection: vi.fn(),

--- a/frontend/src/types/collections.ts
+++ b/frontend/src/types/collections.ts
@@ -7,7 +7,6 @@ export interface Collection {
   name: string
   description: string
   mods: ModSubscription[]
-  isActive: boolean
 }
 
 export interface NewCollection {


### PR DESCRIPTION
The Control Panel mod-collection dropdown only updated local UI state and
seeded itself from the first collection in the list, so a selected
collection was never saved and reverted to the first one on refresh. There
was also no reachable way to mark a collection active from the Mods area.

- Control Panel: seed the dropdown from the server config's persisted
  collection_id (falling back to the first collection only when nothing is
  saved yet) and persist changes via PATCH /server/<id> so the choice
  survives a refresh and is used when the server starts.
- Collection detail page: add a "Set as Active" action (with an Active
  indicator) that assigns the collection to the server config.
- Replace the misleading "not yet integrated" helper text.

The active collection remains driven by ServerConfig.collection_id, which
the Collections table's Active column already reflects.

https://claude.ai/code/session_01UpmvJi2JRSmYnmwgYYE7Ds